### PR TITLE
feat: パスワードリセット後にメールチェックを促す画面への遷移を実装

### DIFF
--- a/native/app/screens/PasswordReset.tsx
+++ b/native/app/screens/PasswordReset.tsx
@@ -49,7 +49,7 @@ const PasswordReset = function PasswordReset(props: Props): ReactElement {
       />
       <Button
         disabled={hasError}
-        onPress={() => undefined}
+        onPress={() => navigation.navigate('SignUpCheckEmail', {email: formData.email})}
         title='メールを送信する'
       />
     </View>


### PR DESCRIPTION
## やったこと

- パスワードリセット後のメール確認への遷移

### レビュー時のポイント

- サインアップ後のメール確認と一緒の画面なので、そこに飛ばす形にしたけどいいですかね

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
