### PR TITLE
楽天BooksAPIを使った検索関数の実装

### DIFF
--- a/.github/workflows/ci-native-for-all.yaml
+++ b/.github/workflows/ci-native-for-all.yaml
@@ -6,6 +6,9 @@ on:
       - '.github/workflows/ci-native-for-all.yaml'
       - 'native/**'
 
+env:
+  RAKUTEN_BOOKS_APPLICATION_ID: ${{ secrets.RAKUTEN_BOOKS_APPLICATION_ID }}
+
 jobs:
   build_and_test:
     name: Build and Test
@@ -50,8 +53,6 @@ jobs:
 
       - name: Test
         run: yarn test
-        env:
-          RAKUTEN_BOOKS_APPLICATION_ID: ${{ secrets.RAKUTEN_BOOKS_APPLICATION_ID }}
 
       # - name: Use Expo ${{ matrix.expo }}
       #   uses: expo/expo-github-action@v5

--- a/.github/workflows/ci-native-for-all.yaml
+++ b/.github/workflows/ci-native-for-all.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Test
         run: yarn test
+        env:
+          RAKUTEN_BOOKS_APPLICATION_ID: ${{ secrets.RAKUTEN_BOOKS_APPLICATION_ID }}
 
       # - name: Use Expo ${{ matrix.expo }}
       #   uses: expo/expo-github-action@v5

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -1,21 +1,22 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { IErrorResponse, ISearchResponse } from '~/types/response/external/rakuten-books';
 
 const baseUrl = 'https://app.rakuten.co.jp/services/api/BooksBook/Search';
 const version = '20170404';
 const format = 'json';
 const formatVersion = 2;
-const applicationId = '1053511986137691200';
+const hits = 30;
 
+const applicationId = process.env.RAKUTEN_BOOKS_APPLICATION_ID;
 
-export async function searchBook(param: string) {
-  const url = `${baseUrl}/${version}?format=${format}&title=${encodeURI(param)}&formatVersion=${formatVersion}&applicationId=${applicationId}`;
+export async function searchBookByTitle(title: string, page = 1) {
+  const url = `${baseUrl}/${version}?format=${format}&title=${encodeURI(title)}&formatVersion=${formatVersion}&applicationId=${applicationId}&page=${page}&hits=${hits}`;
 
   return axios.get(url)
-    .then((res) => {
-      console.log(res.data);
+    .then((res: AxiosResponse<ISearchResponse>) => {
       return res;
     })
-    .catch((err) => {
-      return err;
+    .catch((err: AxiosResponse<IErrorResponse>) => {
+      return Promise.reject(err);
     });
 }

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
+import externalInstance from '~/lib//axios/external';
+import { AxiosResponse } from 'axios';
 import { IErrorResponse, ISearchResponse } from '~/types/response/external/rakuten-books';
 
 const baseUrl = 'https://app.rakuten.co.jp/services/api/BooksBook/Search';
@@ -12,7 +13,7 @@ const applicationId = process.env.RAKUTEN_BOOKS_APPLICATION_ID;
 export async function searchBookByTitle(title: string, page = 1) {
   const url = `${baseUrl}/${version}?format=${format}&title=${encodeURI(title)}&formatVersion=${formatVersion}&applicationId=${applicationId}&page=${page}&hits=${hits}`;
 
-  return axios.get(url)
+  return externalInstance.get(url)
     .then((res: AxiosResponse<ISearchResponse>) => {
       return res;
     })

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { IErrorResponse, ISearchResponse } from '~/types/response/external/rakuten-books';
 
 const baseUrl = 'https://app.rakuten.co.jp/services/api/BooksBook/Search';

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+const baseUrl = 'https://app.rakuten.co.jp/services/api/BooksBook/Search';
+const version = '20170404';
+const format = 'json';
+const formatVersion = 2;
+const applicationId = '1053511986137691200';
+
+
+export async function searchBook(param: string) {
+  const url = `${baseUrl}/${version}?format=${format}&title=${encodeURI(param)}&formatVersion=${formatVersion}&applicationId=${applicationId}`;
+
+  return axios.get(url)
+    .then((res) => {
+      console.log(res.data);
+      return res;
+    })
+    .catch((err) => {
+      return err;
+    });
+}

--- a/native/app/types/response/external/rakuten-books/index.ts
+++ b/native/app/types/response/external/rakuten-books/index.ts
@@ -1,0 +1,49 @@
+export interface ISearchResponse {
+  Items: ISearchResultItem[];
+  pageCount: number;
+  hits: number;
+  last: number;
+  count: number;
+  page: number;
+  carrier: number;
+  GenreInformation: any[];
+  first: number;
+}
+
+export interface ISearchResultItem {
+  limitedFlag: number;
+  authorKana: string;
+  author: string;
+  subTitle: string;
+  seriesNameKana: string;
+  title: string;
+  subTitleKana: string;
+  itemCaption: string;
+  publisherName: string;
+  listPrice: number;
+  isbn: string;
+  largeImageUrl: string;
+  mediumImageUrl: string;
+  titleKana: string;
+  availability: string;
+  postageFlag: number;
+  salesDate: string;
+  contents: string;
+  smallImageUrl: string;
+  discountPrice: number;
+  itemPrice: number;
+  size: string;
+  booksGenreId: string;
+  affiliateUrl: string;
+  seriesName: string;
+  reviewCount: number;
+  reviewAverage: string;
+  discountRate: number;
+  chirayomiUrl: string;
+  itemUrl: string;
+}
+
+export interface IErrorResponse {
+  error: string
+  error_description: string
+}

--- a/native/jest.config.js
+++ b/native/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'jest-expo',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  setupFiles: ['dotenv/config'],
   testMatch: [
     '**/*.test.ts?(x)'
   ]

--- a/native/test/lib/rakute-books/index.test.ts
+++ b/native/test/lib/rakute-books/index.test.ts
@@ -1,0 +1,12 @@
+import 'jest';
+import {searchBook} from '~/lib/rakuten-books';
+
+describe('search book', () => {
+  it('return 200 response when send valid request', async () => {
+    const title = 'ちはやふる';
+    const got = await searchBook(title);
+
+    expect(got).toBeTruthy;
+    expect(got.status).toEqual(200);
+  });
+});

--- a/native/test/lib/rakute-books/index.test.ts
+++ b/native/test/lib/rakute-books/index.test.ts
@@ -1,12 +1,28 @@
 import 'jest';
-import {searchBook} from '~/lib/rakuten-books';
+import {searchBookByTitle} from '~/lib/rakuten-books';
 
 describe('search book', () => {
-  it('return 200 response when send valid request', async () => {
+  it('[Normal](real-api) return 200 response when send valid request', async () => {
     const title = 'ちはやふる';
-    const got = await searchBook(title);
 
+    await searchBookByTitle(title)
+      .then((got) => {
+        expect(got).toBeTruthy;
+        expect(got.status).toEqual(200);
+      });
+  });
+
+  it('[Normal](real-api) send valid request with page', async () => {
+    const title = 'ちはやふる';
+
+    const got = await searchBookByTitle(title);
     expect(got).toBeTruthy;
-    expect(got.status).toEqual(200);
+    expect(got.data.page).toBe(1);
+    expect(got.data.Items.length).toBe(30);
+
+    const got2 = await searchBookByTitle(title, got.data.page + 1);
+    expect(got2).toBeTruthy;
+    expect(got2.data.page).toBe(2);
+    expect(got2.data.Items.length).toBe(30);
   });
 });


### PR DESCRIPTION
## やったこと

- 楽天BooksAPIを使ってタイトルを元に書籍検索できるようにした．
- レスポンスの型定義
- 成功パターンでのテスト記述

### レビュー時のポイント

- 型定義

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

- 実際の検索機能の差し替え
- mock化して失敗パターンのテスト

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

- 環境変数`RAKUTEN_BOOKS_APPLICATION_ID`を追加する必要がある．

<!-- マージ後に必要な操作などがあればここに -->
