### PR TITLE
feature: ユーザサムネイルアップロードAPIの実装

### DIFF
--- a/api/server/user/config/grpc.go
+++ b/api/server/user/config/grpc.go
@@ -80,7 +80,7 @@ func (s *grpcServer) Stop() {
  * ServerOptions
  */
 func grpcServerOptions(logPath, logLevel string) ([]grpc.ServerOption, error) {
-	streamInterceptors, err := grpcStreamServerInterceptors()
+	streamInterceptors, err := grpcStreamServerInterceptors(logPath, logLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +101,20 @@ func grpcServerOptions(logPath, logLevel string) ([]grpc.ServerOption, error) {
 /*
  * ServerOptions - StremServerInterceptor
  */
-func grpcStreamServerInterceptors() ([]grpc.StreamServerInterceptor, error) {
-	interceptors := []grpc.StreamServerInterceptor{}
+func grpcStreamServerInterceptors(logPath, logLevel string) ([]grpc.StreamServerInterceptor, error) {
+	logger, err := newLogger(logPath, logLevel)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []grpc_zap.Option{}
+
+	interceptors := []grpc.StreamServerInterceptor{
+		grpc_ctxtags.StreamServerInterceptor(),
+		grpc_prometheus.StreamServerInterceptor,
+		grpc_zap.StreamServerInterceptor(logger, opts...),
+		grpc_recovery.StreamServerInterceptor(),
+	}
 
 	return interceptors, nil
 }

--- a/api/server/user/internal/application/auth.go
+++ b/api/server/user/internal/application/auth.go
@@ -19,6 +19,7 @@ type AuthApplication interface {
 	UpdatePassword(ctx context.Context, in *input.UpdateAuthPassword, u *user.User) error
 	UpdateProfile(ctx context.Context, in *input.UpdateAuthProfile, u *user.User) error
 	UpdateAddress(ctx context.Context, in *input.UpdateAuthAddress, u *user.User) error
+	UploadThumbnail(ctx context.Context, in *input.UploadAuthThumbnail, u *user.User) (string, error)
 }
 
 type authApplication struct {
@@ -153,6 +154,17 @@ func (a *authApplication) UpdateAddress(ctx context.Context, in *input.UpdateAut
 	}
 
 	return a.userService.Update(ctx, u)
+}
+
+func (a *authApplication) UploadThumbnail(
+	ctx context.Context, in *input.UploadAuthThumbnail, u *user.User,
+) (string, error) {
+	err := a.authRequestValidation.UploadAuthThumbnail(in)
+	if err != nil {
+		return "", err
+	}
+
+	return a.userService.UploadThumbnail(ctx, u.ID, in.Thumbnail)
 }
 
 func (a *authApplication) getThumbnailURL(ctx context.Context, uid string, thumbnail string) (string, error) {

--- a/api/server/user/internal/application/input/auth.go
+++ b/api/server/user/internal/application/input/auth.go
@@ -40,3 +40,8 @@ type UpdateAuthAddress struct {
 	AddressLine1  string `json:"addressLine1" validate:"required,max=64"`
 	AddressLine2  string `json:"addressLine2" validate:"max=64"`
 }
+
+// UploadAuthThumbnail - サムネイルアップロードのリクエスト
+type UploadAuthThumbnail struct {
+	Thumbnail []byte `json:"thumbnail" validate:"required"`
+}

--- a/api/server/user/internal/application/validation/auth.go
+++ b/api/server/user/internal/application/validation/auth.go
@@ -13,6 +13,7 @@ type AuthRequestValidation interface {
 	UpdateAuthPassword(in *input.UpdateAuthPassword) error
 	UpdateAuthProfile(in *input.UpdateAuthProfile) error
 	UpdateAuthAddress(in *input.UpdateAuthAddress) error
+	UploadAuthThumbnail(in *input.UploadAuthThumbnail) error
 }
 
 type authRequestValidation struct {
@@ -75,5 +76,15 @@ func (v *authRequestValidation) UpdateAuthAddress(in *input.UpdateAuthAddress) e
 	}
 
 	err := xerrors.New("Failed to UpdateAuthAddress for RequestValidation")
+	return exception.InvalidRequestValidation.New(err, ves...)
+}
+
+func (v *authRequestValidation) UploadAuthThumbnail(in *input.UploadAuthThumbnail) error {
+	ves := v.validator.Run(in, "")
+	if len(ves) == 0 {
+		return nil
+	}
+
+	err := xerrors.New("Failed to UploadAuthThumbnail for RequestValidation")
 	return exception.InvalidRequestValidation.New(err, ves...)
 }

--- a/api/server/user/internal/interface/grpc/v1/auth.go
+++ b/api/server/user/internal/interface/grpc/v1/auth.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"io"
 
 	"github.com/calmato/gran-book/api/server/user/internal/application"
 	"github.com/calmato/gran-book/api/server/user/internal/application/input"
@@ -142,6 +143,49 @@ func (s *AuthServer) UpdateAuthAddress(
 
 	res := getAuthResponse(u)
 	return res, nil
+}
+
+// UploadAuthThumbnail - サムネイルアップロード
+func (s *AuthServer) UploadAuthThumbnail(stream pb.AuthService_UploadAuthThumbnailServer) error {
+	ctx := stream.Context()
+	thumbnailBytes := map[int][]byte{}
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			u, err := s.AuthApplication.Authentication(ctx)
+			if err != nil {
+				return errorHandling(err)
+			}
+
+			// 分割して送信されてきたサムネイルのバイナリをまとめる
+			thumbnail := []byte{}
+			for i := 0; i < len(thumbnailBytes); i++ {
+				thumbnail = append(thumbnail, thumbnailBytes[i]...)
+			}
+
+			in := &input.UploadAuthThumbnail{
+				Thumbnail: thumbnail,
+			}
+
+			thumbnailURL, err := s.AuthApplication.UploadThumbnail(ctx, in, u)
+			if err != nil {
+				return errorHandling(err)
+			}
+
+			res := &pb.AuthThumbnailResponse{
+				ThumbnailUrl: thumbnailURL,
+			}
+
+			return stream.SendAndClose(res)
+		}
+
+		if err != nil {
+			return errorHandling(err)
+		}
+
+		num := int(req.GetPosition())
+		thumbnailBytes[num] = req.GetThumbnail()
+	}
 }
 
 func getAuthResponse(u *user.User) *pb.AuthResponse {

--- a/api/server/user/mock/application/validation/auth.go
+++ b/api/server/user/mock/application/validation/auth.go
@@ -102,3 +102,17 @@ func (mr *MockAuthRequestValidationMockRecorder) UpdateAuthAddress(in interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAuthAddress", reflect.TypeOf((*MockAuthRequestValidation)(nil).UpdateAuthAddress), in)
 }
+
+// UploadAuthThumbnail mocks base method
+func (m *MockAuthRequestValidation) UploadAuthThumbnail(in *input.UploadAuthThumbnail) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadAuthThumbnail", in)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadAuthThumbnail indicates an expected call of UploadAuthThumbnail
+func (mr *MockAuthRequestValidationMockRecorder) UploadAuthThumbnail(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadAuthThumbnail", reflect.TypeOf((*MockAuthRequestValidation)(nil).UploadAuthThumbnail), in)
+}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* ユーザサムネイルアップロードAPIの実装

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->
* 初めてStreaming RPCを使ってみたのでInterface層がちゃんと書けてるか怪しい...

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* Streaming RPCのログをUnary RPCのログ形式に合わせる
* テストの作成
* ユーザサムネイルアップロードを別エンドポイントとして作成したので、不要になるコードの削除

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* #184 `feature: ユーザのサムネアップロード用のProto作成` の続き
* #185 `feature: ユーザのサムネアップロード用のエンドポイント作成` の続き
