### PR TITLE
test: 管理者情報編集機能のテスト作成

### DIFF
--- a/web/admin/app/store/admin.ts
+++ b/web/admin/app/store/admin.ts
@@ -145,7 +145,7 @@ export default class AdminModule extends VuexModule {
 
     return new Promise((resolve: () => void, reject: (reason: ApiError) => void) => {
       $axios
-        .patch(`/v1/admin/${userId}`, req)
+        .$patch(`/v1/admin/${userId}`, req)
         .then(() => {
           // TODO: set user
           resolve()

--- a/web/admin/spec/components/organisms/AdminEditForm.spec.ts
+++ b/web/admin/spec/components/organisms/AdminEditForm.spec.ts
@@ -1,0 +1,94 @@
+import { shallowMount } from '@vue/test-utils'
+import * as Options from '~~/spec/helpers/component-helper'
+import AdminEditForm from '~/components/organisms/AdminEditForm.vue'
+import { AdminEditOptions, IAdminEditForm, IAdminEditParams } from '~/types/forms'
+
+describe('components/organisms/AdminEditForm', () => {
+  let wrapper: any
+
+  beforeEach(() => {
+    const params: IAdminEditParams = {
+      email: '',
+      phoneNumber: '',
+      role: 2,
+      lastName: '',
+      firstName: '',
+      lastNameKana: '',
+      firstNameKana: '',
+      thumbnail: null,
+      thumbnailUrl: '',
+    }
+    const form: IAdminEditForm = { params, options: AdminEditOptions }
+
+    wrapper = shallowMount(AdminEditForm, {
+      ...Options,
+      propsData: { form },
+    })
+  })
+
+  describe('script', () => {
+    describe('props', () => {
+      describe('form', () => {
+        it('初期値', () => {
+          expect(wrapper.props().form).toEqual({
+            params: {
+              email: '',
+              phoneNumber: '',
+              role: 2,
+              lastName: '',
+              firstName: '',
+              lastNameKana: '',
+              firstNameKana: '',
+              thumbnail: null,
+              thumbnailUrl: '',
+            },
+            options: AdminEditOptions,
+          })
+        })
+
+        it('値が代入されること', async () => {
+          await wrapper.setProps({
+            form: {
+              params: {
+                email: 'test@calmato.com',
+                phoneNumber: '000-0000-0000',
+                role: 1,
+                lastName: 'テスト',
+                firstName: 'ユーザー',
+                lastNameKana: 'てすと',
+                firstNameKana: 'ゆーざー',
+                thumbnail: null,
+                thumbnailUrl: 'https://calmato.com/images/01',
+              },
+              options: AdminEditOptions,
+            },
+          })
+          expect(wrapper.props().form).toEqual({
+            params: {
+              email: 'test@calmato.com',
+              phoneNumber: '000-0000-0000',
+              role: 1,
+              lastName: 'テスト',
+              firstName: 'ユーザー',
+              lastNameKana: 'てすと',
+              firstNameKana: 'ゆーざー',
+              thumbnail: null,
+              thumbnailUrl: 'https://calmato.com/images/01',
+            },
+            options: AdminEditOptions,
+          })
+        })
+      })
+    })
+
+    describe('data', () => {
+      it('roleItems', () => {
+        expect(wrapper.vm.roleItems).toEqual([
+          { text: '管理者', value: 1 },
+          { text: '開発者', value: 2 },
+          { text: '運用者', value: 3 },
+        ])
+      })
+    })
+  })
+})

--- a/web/admin/spec/components/templates/AdminList.spec.ts
+++ b/web/admin/spec/components/templates/AdminList.spec.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils'
 import * as Options from '~~/spec/helpers/component-helper'
 import AdminList from '~/components/templates/AdminList.vue'
-import { AdminNewOptions } from '~/types/forms'
+import { AdminEditOptions, AdminNewOptions } from '~/types/forms'
 
 describe('components/templates/AdminList', () => {
   let wrapper: any
@@ -192,6 +192,56 @@ describe('components/templates/AdminList', () => {
           expect(wrapper.props().total).toBe(10)
         })
       })
+
+      describe('editForm', () => {
+        it('初期値', () => {
+          expect(wrapper.props().editForm).toEqual({})
+        })
+
+        it('値が代入されること', async () => {
+          await wrapper.setProps({
+            editForm: {
+              params: {
+                email: 'test@calmato.com',
+                phoneNumber: '000-0000-0000',
+                role: 1,
+                lastName: 'テスト',
+                firstName: 'ユーザー',
+                lastNameKana: 'てすと',
+                firstNameKana: 'ゆーざー',
+                thumbnail: null,
+                thumbnailUrl: 'https://calmato.com/images/01',
+              },
+              options: AdminEditOptions,
+            },
+          })
+          expect(wrapper.props().editForm).toEqual({
+            params: {
+              email: 'test@calmato.com',
+              phoneNumber: '000-0000-0000',
+              role: 1,
+              lastName: 'テスト',
+              firstName: 'ユーザー',
+              lastNameKana: 'てすと',
+              firstNameKana: 'ゆーざー',
+              thumbnail: null,
+              thumbnailUrl: 'https://calmato.com/images/01',
+            },
+            options: AdminEditOptions,
+          })
+        })
+      })
+
+      describe('editDialog', () => {
+        it('初期値', () => {
+          expect(wrapper.props().editDialog).toBeFalsy()
+        })
+
+        it('値が代入されること', async () => {
+          await wrapper.setProps({ editDialog: true })
+          expect(wrapper.props().editDialog).toBeTruthy()
+        })
+      })
     })
 
     describe('data', () => {
@@ -227,6 +277,20 @@ describe('components/templates/AdminList', () => {
           await wrapper.vm.onClickEditButton(1)
           expect(wrapper.emitted('edit')).toBeTruthy()
           expect(wrapper.emitted('edit')[0][0]).toBe(1)
+        })
+      })
+
+      describe('onClickEditClose', () => {
+        it('emitが実行されること', async () => {
+          await wrapper.vm.onClickEditClose()
+          expect(wrapper.emitted('edit:close')).toBeTruthy()
+        })
+      })
+
+      describe('onClickUpdateButton', () => {
+        it('emitが実行されること', async () => {
+          await wrapper.vm.onClickUpdateButton()
+          expect(wrapper.emitted('update')).toBeTruthy()
         })
       })
 

--- a/web/admin/spec/helpers/response/admin.ts
+++ b/web/admin/spec/helpers/response/admin.ts
@@ -69,4 +69,25 @@ export const post = {
     createdAt: '2021-01-01 00:00:00',
     updatedAt: '2021-01-01 00:00:00',
   },
+  '/v1/admin/00000000-0000-0000-00000000/thumbnail': {
+    thumbnailUrl: 'https://calmato.com/images/01',
+  },
+}
+
+export const patch = {
+  '/v1/admin/00000000-0000-0000-00000000': {
+    id: '00000000-0000-0000-00000000',
+    username: 'test-user',
+    email: 'test@calmato.com',
+    phoneNumber: '000-0000-0000',
+    role: 0,
+    thumbnailUrl: 'https://calmato.com/images/01',
+    selfIntroduction: 'よろしくお願いします',
+    lastName: 'テスト',
+    firstName: 'ユーザ',
+    lastNameKana: 'てすと',
+    firstNameKana: 'ゆーざ',
+    createdAt: '2021-01-01 00:00:00',
+    updatedAt: '2021-01-01 00:00:00',
+  },
 }

--- a/web/admin/spec/helpers/response/index.ts
+++ b/web/admin/spec/helpers/response/index.ts
@@ -23,6 +23,7 @@ export default {
     ...AuthStore.post,
   },
   patch: {
+    ...AdminStore.patch,
     ...AuthStore.patch,
   },
   put: {},

--- a/web/admin/spec/store/admin.spec.ts
+++ b/web/admin/spec/store/admin.spec.ts
@@ -1,7 +1,15 @@
 import { setup, setSafetyMode, refresh } from '~~/spec/helpers/store-helper'
 import { AdminStore } from '~/store'
 import { ApiError } from '~/types/exception'
-import { AdminEditOptions, AdminNewOptions, IAdminEditForm, IAdminEditParams, IAdminListForm, IAdminNewForm, IAdminNewParams } from '~/types/forms'
+import {
+  AdminEditOptions,
+  AdminNewOptions,
+  IAdminEditForm,
+  IAdminEditParams,
+  IAdminListForm,
+  IAdminNewForm,
+  IAdminNewParams,
+} from '~/types/forms'
 
 describe('store/admin', () => {
   beforeEach(() => {

--- a/web/admin/spec/store/admin.spec.ts
+++ b/web/admin/spec/store/admin.spec.ts
@@ -1,7 +1,7 @@
 import { setup, setSafetyMode, refresh } from '~~/spec/helpers/store-helper'
 import { AdminStore } from '~/store'
 import { ApiError } from '~/types/exception'
-import { AdminNewOptions, IAdminListForm, IAdminNewForm, IAdminNewParams } from '~/types/forms'
+import { AdminEditOptions, AdminNewOptions, IAdminEditForm, IAdminEditParams, IAdminListForm, IAdminNewForm, IAdminNewParams } from '~/types/forms'
 
 describe('store/admin', () => {
   beforeEach(() => {
@@ -163,6 +163,93 @@ describe('store/admin', () => {
         it('rejectが返されること', async () => {
           const err = new ApiError(400, 'api error', { status: 400, code: 0, message: 'api error', errors: [] })
           await expect(AdminStore.createAdmin(form)).rejects.toThrow(err)
+        })
+      })
+    })
+
+    describe('updateAdmin', () => {
+      describe('success', () => {
+        let form: IAdminEditForm
+        let payload: { userId: string; form: IAdminEditForm }
+        beforeEach(() => {
+          setSafetyMode(true)
+          const params: IAdminEditParams = {
+            email: 'test@calmato.com',
+            phoneNumber: '000-0000-0000',
+            role: 1,
+            lastName: 'テスト',
+            firstName: 'ユーザ',
+            lastNameKana: 'てすと',
+            firstNameKana: 'ゆーざ',
+            thumbnail: null,
+            thumbnailUrl: 'https://calmato.com/images/01',
+          }
+          form = { params, options: AdminEditOptions }
+          payload = { userId: '00000000-0000-0000-00000000', form }
+        })
+
+        // TODO: 実装後、テストを作成
+        // it('stateが更新されていること', async () => {})
+
+        it('resolveが返されること', async () => {
+          await expect(AdminStore.updateAdmin(payload)).resolves.toBeUndefined()
+        })
+      })
+
+      describe('failure', () => {
+        let form: IAdminEditForm
+        let payload: { userId: string; form: IAdminEditForm }
+        beforeEach(() => {
+          setSafetyMode(false)
+          const params: IAdminEditParams = {
+            email: '',
+            phoneNumber: '000-0000-0000',
+            role: 0,
+            lastName: '',
+            firstName: '',
+            lastNameKana: '',
+            firstNameKana: '',
+            thumbnail: null,
+            thumbnailUrl: '',
+          }
+          form = { params, options: AdminEditOptions }
+          payload = { userId: '00000000-0000-0000-00000000', form }
+        })
+
+        it('rejectが返されること', async () => {
+          const err = new ApiError(400, 'api error', { status: 400, code: 0, message: 'api error', errors: [] })
+          await expect(AdminStore.updateAdmin(payload)).rejects.toThrow(err)
+        })
+      })
+    })
+
+    describe('uploadThumbnail', () => {
+      describe('success', () => {
+        let file: File
+        let payload: { userId: string; file: File }
+        beforeEach(() => {
+          setSafetyMode(true)
+          file = new File(['thumbnail'], 'thumbnail.png', { lastModified: Date.now(), type: 'image/png' })
+          payload = { userId: '00000000-0000-0000-00000000', file }
+        })
+
+        it('resolveが返されること', async () => {
+          await expect(AdminStore.uploadThumbnail(payload)).resolves.toBe('https://calmato.com/images/01')
+        })
+      })
+
+      describe('failure', () => {
+        let file: File
+        let payload: { userId: string; file: File }
+        beforeEach(() => {
+          setSafetyMode(false)
+          file = new File(['thumbnail'], 'thumbnail.png', { lastModified: Date.now(), type: 'image/png' })
+          payload = { userId: '00000000-0000-0000-00000000', file }
+        })
+
+        it('rejectが返されること', async () => {
+          const err = new ApiError(400, 'api error', { status: 400, code: 0, message: 'api error', errors: [] })
+          await expect(AdminStore.uploadThumbnail(payload)).rejects.toThrow(err)
         })
       })
     })


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* 管理者情報編集機能のテスト作成

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* #257 feature: 管理者情報編集画面のUI実装 の続き
* #258 feature: 管理者情報編集機能の型定義 の続き
* #261 feature: 管理者情報編集機能の実装 の続き