### PR TITLE
fix: 書籍APIのレスポンス修正

### DIFF
--- a/api/gateway/native/src/routes/v1/book.ts
+++ b/api/gateway/native/src/routes/v1/book.ts
@@ -36,7 +36,7 @@ import {
 import { ICreateBookRequest, IUpdateBookRequest } from '~/types/request'
 import {
   IBookResponse,
-  IBookResponseBookshelf,
+  IBookResponseDetail,
   IBookReviewListResponse,
   IBookReviewListResponseUser,
   IReviewResponse,
@@ -267,7 +267,7 @@ router.get(
   }
 )
 
-function setBookResponse(bookOutput: IBookOutput, bookshelfOutput?: any): IBookResponse {
+function setBookResponse(bookOutput: IBookOutput, bookshelfOutput?: IBookshelfOutput): IBookResponse {
   const authorNames: string[] = bookOutput.authors.map((item: IBookOutputAuthor) => {
     return item.name
   })
@@ -276,7 +276,7 @@ function setBookResponse(bookOutput: IBookOutput, bookshelfOutput?: any): IBookR
     return item.nameKana
   })
 
-  const response: IBookResponse = {
+  const detail: IBookResponseDetail = {
     id: bookOutput.id,
     title: bookOutput.title,
     titleKana: bookOutput.titleKana,
@@ -291,20 +291,16 @@ function setBookResponse(bookOutput: IBookOutput, bookshelfOutput?: any): IBookR
     authorKana: authorNameKanas.join('/'),
     createdAt: bookOutput.createdAt,
     updatedAt: bookOutput.updatedAt,
-    bookshelf: undefined,
   }
 
-  if (bookshelfOutput) {
-    const bookshelf: IBookResponseBookshelf = {
-      id: 0,
-      status: 0,
-      impression: '',
-      readOn: '',
-      createdAt: '',
-      updatedAt: '',
-    }
-
-    response.bookshelf = bookshelf
+  const response: IBookResponse = {
+    id: bookshelfOutput?.id || 0,
+    status: bookshelfOutput?.status || 0,
+    impression: '',
+    readOn: bookshelfOutput?.readOn || '',
+    createdAt: bookshelfOutput?.createdAt || '',
+    updatedAt: bookshelfOutput?.updatedAt || '',
+    detail,
   }
 
   return response

--- a/api/gateway/native/src/routes/v1/book.ts
+++ b/api/gateway/native/src/routes/v1/book.ts
@@ -296,7 +296,7 @@ function setBookResponse(bookOutput: IBookOutput, bookshelfOutput?: IBookshelfOu
   const response: IBookResponse = {
     id: bookshelfOutput?.id || 0,
     status: bookshelfOutput?.status || 0,
-    impression: '',
+    impression: bookshelfOutput?.review?.impression || '',
     readOn: bookshelfOutput?.readOn || '',
     createdAt: bookshelfOutput?.createdAt || '',
     updatedAt: bookshelfOutput?.updatedAt || '',

--- a/api/gateway/native/src/routes/v1/bookshelf.ts
+++ b/api/gateway/native/src/routes/v1/bookshelf.ts
@@ -281,15 +281,11 @@ function setBookshelfResponse(output: IBookshelfOutput): IBookshelfResponse {
   const response: IBookshelfResponse = {
     id: output.id,
     status: output.status,
-    impression: '',
+    impression: output.review?.impression || '',
     readOn: output.readOn,
     createdAt: output.createdAt,
     updatedAt: output.updatedAt,
     detail,
-  }
-
-  if (output.review) {
-    response.impression = output.review.impression
   }
 
   return response

--- a/api/gateway/native/src/routes/v1/bookshelf.ts
+++ b/api/gateway/native/src/routes/v1/bookshelf.ts
@@ -280,7 +280,6 @@ function setBookshelfResponse(output: IBookshelfOutput): IBookshelfResponse {
 
   const response: IBookshelfResponse = {
     id: output.id,
-    userId: output.userId,
     status: output.status,
     impression: '',
     readOn: output.readOn,

--- a/api/gateway/native/src/types/response/book.ts
+++ b/api/gateway/native/src/types/response/book.ts
@@ -1,5 +1,15 @@
 export interface IBookResponse {
   id: number
+  status: number
+  readOn: string
+  impression: string
+  createdAt: string
+  updatedAt: string
+  detail: IBookResponseDetail
+}
+
+export interface IBookResponseDetail {
+  id: number
   title: string
   titleKana: string
   description: string
@@ -11,16 +21,6 @@ export interface IBookResponse {
   rakutenGenreId: string
   author: string
   authorKana: string
-  createdAt: string
-  updatedAt: string
-  bookshelf?: IBookResponseBookshelf
-}
-
-export interface IBookResponseBookshelf {
-  id: number
-  status: number
-  impression: string
-  readOn: string
   createdAt: string
   updatedAt: string
 }

--- a/api/gateway/native/src/types/response/bookshelf.ts
+++ b/api/gateway/native/src/types/response/bookshelf.ts
@@ -1,6 +1,5 @@
 export interface IBookshelfResponse {
   id: number
-  userId: string
   status: number
   readOn: string
   impression: string

--- a/docs/12_backend/11_swagger/native.apiv1.yaml
+++ b/docs/12_backend/11_swagger/native.apiv1.yaml
@@ -1226,44 +1226,44 @@ components:
         id:
           type: integer
           format: int64
-        title:
+        status:
+          type: integer
+          format: int32
+        readOn:
           type: string
-        titleKana:
-          type: string
-        description:
-          type: string
-        isbn:
-          type: string
-        publisher:
-          type: string
-        publishedOn:
-          type: string
-        thumbnailUrl:
-          type: string
-        rakutenUrl:
-          type: string
-        rakutenGenreId:
-          type: string
-        author:
-          type: string
-        authorKana:
+        impression:
           type: string
         createdAt:
           type: string
         updatedAt:
           type: string
-        bookshelf:
+        detail:
           type: object
           properties:
             id:
               type: integer
               format: int64
-            status:
-              type: integer
-              format: int32
-            readOn:
+            title:
               type: string
-            impression:
+            titleKana:
+              type: string
+            description:
+              type: string
+            isbn:
+              type: string
+            publisher:
+              type: string
+            publishedOn:
+              type: string
+            thumbnailUrl:
+              type: string
+            rakutenUrl:
+              type: string
+            rakutenGenreId:
+              type: string
+            author:
+              type: string
+            authorKana:
               type: string
             createdAt:
               type: string


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* 本棚内の書籍一覧取得API (/v1/users/{userId}/books) と 書籍情報取得API (/v1​/books​/{isbn}) のレスポンスが同じ形になるよう修正

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* @wf-yamaday  にLINEで指摘もらった箇所修正しました!!
* マージ後すぐに検証環境(GCP)のAPIが更新されるように、Masterブランチの方にプルリク出してます
