### PR TITLE
Feature: 楽天Books APIの検索結果の画面でスクロールによるページネーションの実装

### DIFF
--- a/native/app/components/organisms/SearchResultItemList.tsx
+++ b/native/app/components/organisms/SearchResultItemList.tsx
@@ -1,9 +1,7 @@
 ﻿import React, { ReactElement } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { ISearchResultItem } from '~/types/response/external/rakuten-books';
 import SearchResultItem from '~/components/molecules/SearchResultItem';
-
-const styles = StyleSheet.create({});
 
 interface Props {
   resultItems: ISearchResultItem[];
@@ -15,8 +13,8 @@ const SearchResultItemList = function SearchResultItemList(props: Props): ReactE
 
   return (
     <View>
-      {items.map((item) => (
-        <SearchResultItem key={item.isbn} book={item} onPress={() => props.onPress(item)} />
+      {items.map((item, idx) => (
+        <SearchResultItem key={idx} book={item} onPress={() => props.onPress(item)} />
       ))}
     </View>
   );

--- a/native/app/components/organisms/SearchResultItemList.tsx
+++ b/native/app/components/organisms/SearchResultItemList.tsx
@@ -1,21 +1,21 @@
 ﻿import React, { ReactElement } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { ISearchResponse, ISearchResultItem } from '~/types/response/external/rakuten-books';
+import { ISearchResultItem } from '~/types/response/external/rakuten-books';
 import SearchResultItem from '~/components/molecules/SearchResultItem';
 
 const styles = StyleSheet.create({});
 
 interface Props {
-  results: ISearchResponse;
+  resultItems: ISearchResultItem[];
   onPress: (item: Partial<ISearchResultItem>) => void;
 }
 
 const SearchResultItemList = function SearchResultItemList(props: Props): ReactElement {
-  const results = props.results;
+  const items = props.resultItems;
 
   return (
     <View>
-      {results.Items.map((item) => (
+      {items.map((item) => (
         <SearchResultItem key={item.isbn} book={item} onPress={() => props.onPress(item)} />
       ))}
     </View>

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -10,6 +10,12 @@ const hits = 30;
 
 const applicationId = process.env.RAKUTEN_BOOKS_APPLICATION_ID;
 
+/**
+ * 楽天 Book APIを利用して書籍を検索する関数
+ * @param title 検索したい書籍のタイトル
+ * @param page ページ番号（任意、デフォルト値は1）
+ * @returns Promise<AxiosResponse<ISearchResponse>>
+ */
 export async function searchBookByTitle(title: string, page = 1) {
   const url = `${baseUrl}/${version}?format=${format}&title=${encodeURI(
     title,

--- a/native/app/lib/rakuten-books/index.ts
+++ b/native/app/lib/rakuten-books/index.ts
@@ -1,6 +1,6 @@
 import externalInstance from '~/lib//axios/external';
 import { AxiosResponse } from 'axios';
-import { IErrorResponse, ISearchResponse } from '~/types/response/external/rakuten-books';
+import { ISearchResponse } from '~/types/response/external/rakuten-books';
 
 const baseUrl = 'https://app.rakuten.co.jp/services/api/BooksBook/Search';
 const version = '20170404';
@@ -26,7 +26,7 @@ export async function searchBookByTitle(title: string, page = 1) {
     .then((res: AxiosResponse<ISearchResponse>) => {
       return res;
     })
-    .catch((err: AxiosResponse<IErrorResponse>) => {
-      return Promise.reject(err);
+    .catch((err) => {
+      return Promise.reject(err.response);
     });
 }

--- a/native/app/screens/Home.tsx
+++ b/native/app/screens/Home.tsx
@@ -6,7 +6,6 @@ import { Header } from 'react-native-elements';
 import HeaderText from '~/components/atoms/HeaderText';
 import BookList from '~/components/molecules/BookList';
 import SearchBar from '~/components/molecules/SearchBar';
-import { searchBookByTitle } from '~/lib/rakuten-books';
 import { HomeTabStackPramList } from '~/types/navigation';
 import { ViewBooks } from '~/types/models/book';
 import { IBook } from '~/types/response';
@@ -64,9 +63,7 @@ const Home = function Home(props: Props): ReactElement {
   const onSubmitEditingCallback = useCallback(() => {
     (async () => {
       if (keyword !== '') {
-        // TODO: titleに変更する？
-        const res = await searchBookByTitle(keyword);
-        if (res) navigation?.navigate('SearchResult', { keyword, results: res.data });
+        navigation?.navigate('SearchResult', { keyword });
       }
     })();
   }, [keyword, navigation]);

--- a/native/app/screens/SearchResult.tsx
+++ b/native/app/screens/SearchResult.tsx
@@ -1,11 +1,13 @@
 ﻿import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import HeaderWithBackButton from '~/components/organisms/HeaderWithBackButton';
 import SearchResultItemList from '~/components/organisms/SearchResultItemList';
+import { searchBookByTitle } from '~/lib/rakuten-books';
 import { HomeTabStackPramList } from '~/types/navigation';
+import { ISearchResponse, ISearchResultItem } from '~/types/response/external/rakuten-books';
 import { COLOR } from '~~/constants/theme';
 
 const styles = StyleSheet.create({
@@ -22,8 +24,12 @@ interface Props {
 }
 
 const SearchResult = function SearchResult(props: Props): ReactElement {
-  const { keyword, results } = props.route.params;
+  const { keyword } = props.route.params;
   const navigation = props.navigation;
+
+  const [result, setResult] = useState<ISearchResponse>();
+  const [books, setBooks] = useState<ISearchResultItem[]>([]);
+  const [page, setPage] = useState<number>(1);
 
   const selectBook = useCallback(
     (item) => {
@@ -32,12 +38,34 @@ const SearchResult = function SearchResult(props: Props): ReactElement {
     [navigation],
   );
 
+  // TODO: パフォーマンス面で要リファクタ
+  useEffect(() => {
+    let unmounted = false;
+    const f = async () => {
+      const res = await searchBookByTitle(keyword, page);
+      if (!unmounted && page === 1) {
+        setResult(res.data);
+        setBooks(res.data.Items);
+      } else if (result && page <= result?.pageCount) {
+        setBooks([...books, ...res.data.Items]);
+      }
+    };
+    f();
+    return () => {
+      unmounted = true;
+    };
+  }, [page]);
+
   return (
     <View>
       <HeaderWithBackButton onPress={() => navigation.goBack()} title={keyword} />
-      <Text style={styles.totalItemsTextStyle}>検索結果：{results.count}件</Text>
-      <ScrollView style={{ marginBottom: 'auto' }}>
-        <SearchResultItemList results={results} onPress={selectBook} />
+      <Text style={styles.totalItemsTextStyle}>検索結果：{result?.count}件</Text>
+      <ScrollView
+        style={{ marginBottom: 'auto' }}
+        onMomentumScrollEnd={() => {
+          setPage(page + 1);
+        }}>
+        <SearchResultItemList resultItems={books} onPress={selectBook} />
       </ScrollView>
     </View>
   );

--- a/native/app/types/navigation/index.ts
+++ b/native/app/types/navigation/index.ts
@@ -19,7 +19,7 @@ export type AuthStackParamList = {
 
 export type HomeTabStackPramList = {
   Home: undefined;
-  SearchResult: { keyword: string; results: ISearchResponse };
+  SearchResult: { keyword: string; };
   SearchResultBookShow: { book: ISearchResultItem };
   BookShow: { book: IBook };
 };


### PR DESCRIPTION
## やったこと

- 楽天Books APIからの検索結果画面で最下部までスクロールされたらページネーションで次の検索結果を読み込むようにした
- リファクタリング：検索結果画面に遷移する前に検索結果を取得するのではなく、検索結果画面の初期描画で検索結果を取得するようにした

### レビュー時のポイント

- useEffectの部分の実装

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

- useEffectのcleanup処理についての理解が甘いので理解して修正

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
