### PR TITLE
reafactor: テストのフォーマットを統一

### DIFF
--- a/api/server/book/internal/application/auth_test.go
+++ b/api/server/book/internal/application/auth_test.go
@@ -10,24 +10,23 @@ import (
 )
 
 func TestAuthApplication_Authentication(t *testing.T) {
+	type want struct {
+		uid string
+		err error
+	}
+
 	testCases := map[string]struct {
-		Expected struct {
-			UID   string
-			Error error
-		}
+		want want
 	}{
 		"ok": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "00000000-0000-0000-0000-000000000000",
-				Error: nil,
+			want: want{
+				uid:   "00000000-0000-0000-0000-000000000000",
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -35,19 +34,19 @@ func TestAuthApplication_Authentication(t *testing.T) {
 		defer ctrl.Finish()
 
 		asm := mock_auth.NewMockService(ctrl)
-		asm.EXPECT().Authentication(ctx).Return(tc.Expected.UID, tc.Expected.Error)
+		asm.EXPECT().Authentication(ctx).Return(tc.want.uid, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(asm)
 
-			got, err := target.Authentication(ctx)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			uid, err := target.Authentication(ctx)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.UID) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.UID, got)
+			if !reflect.DeepEqual(uid, tc.want.uid) {
+				t.Fatalf("want %#v, but %#v", tc.want.uid, uid)
 				return
 			}
 		})

--- a/api/server/book/internal/application/auth_test.go
+++ b/api/server/book/internal/application/auth_test.go
@@ -20,7 +20,7 @@ func TestAuthApplication_Authentication(t *testing.T) {
 	}{
 		"ok": {
 			want: want{
-				uid:   "00000000-0000-0000-0000-000000000000",
+				uid: "00000000-0000-0000-0000-000000000000",
 				err: nil,
 			},
 		},

--- a/api/server/book/internal/application/validation/book_test.go
+++ b/api/server/book/internal/application/validation/book_test.go
@@ -390,11 +390,11 @@ func TestBookRequestValidation_Book(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.Book(tc.Input)
@@ -488,11 +488,11 @@ func TestBookRequestValidation_Bookshelf(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.Bookshelf(tc.Input)
@@ -540,11 +540,11 @@ func TestBookRequestValidation_ListBookByBookIDs(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.ListBookByBookIDs(tc.Input)
@@ -608,11 +608,11 @@ func TestBookRequestValidation_ListBookshelf(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.ListBookshelf(tc.Input)
@@ -716,11 +716,11 @@ func TestBookRequestValidation_ListBookReview(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.ListBookReview(tc.Input)
@@ -814,11 +814,11 @@ func TestBookRequestValidation_ListUserReview(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewBookRequestValidation()
 
 			got := target.ListUserReview(tc.Input)

--- a/api/server/book/internal/infrastructure/service/auth_test.go
+++ b/api/server/book/internal/infrastructure/service/auth_test.go
@@ -11,33 +11,29 @@ import (
 )
 
 func TestAuthService_Authentication(t *testing.T) {
+	type want struct {
+		uid string
+		err error
+	}
+
 	testCases := map[string]struct {
-		Expected struct {
-			UID   string
-			Error error
-		}
+		want want
 	}{
 		"ok": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "00000000-0000-0000-0000-000000000000",
-				Error: nil,
+			want: want{
+				uid: "00000000-0000-0000-0000-000000000000",
+				err: nil,
 			},
 		},
 		"ng_unauthorized": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "",
-				Error: exception.Unauthorized.New(nil),
+			want: want{
+				uid: "",
+				err: exception.Unauthorized.New(nil),
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -45,19 +41,19 @@ func TestAuthService_Authentication(t *testing.T) {
 		defer ctrl.Finish()
 
 		arm := mock_auth.NewMockRepository(ctrl)
-		arm.EXPECT().Authentication(ctx).Return(tc.Expected.UID, tc.Expected.Error)
+		arm.EXPECT().Authentication(ctx).Return(tc.want.uid, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthService(arm)
 
-			got, err := target.Authentication(ctx)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			uid, err := target.Authentication(ctx)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.UID) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.UID, got)
+			if !reflect.DeepEqual(uid, tc.want.uid) {
+				t.Fatalf("want %#v, but %#v", tc.want.uid, uid)
 				return
 			}
 		})

--- a/api/server/book/internal/infrastructure/service/book_test.go
+++ b/api/server/book/internal/infrastructure/service/book_test.go
@@ -13,25 +13,29 @@ import (
 )
 
 func TestBookService_List(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		books []*book.Book
+		err   error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Books []*book.Book
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Books []*book.Book
-				Error error
-			}{
-				Books: []*book.Book{
+			want: want{
+				books: []*book.Book{
 					{
 						ID:           1,
 						Title:        "テスト書籍",
@@ -47,13 +51,13 @@ func TestBookService_List(t *testing.T) {
 						Reviews:      []*book.Review{},
 					},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -63,19 +67,19 @@ func TestBookService_List(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().List(ctx, tc.Query).Return(tc.Expected.Books, tc.Expected.Error)
+			brm.EXPECT().List(ctx, tc.args.query).Return(tc.want.books, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.List(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				books, err := target.List(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Books) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Books, got)
+				if !reflect.DeepEqual(books, tc.want.books) {
+					t.Fatalf("want %#v, but %#v", tc.want.books, books)
 					return
 				}
 			})
@@ -84,25 +88,29 @@ func TestBookService_List(t *testing.T) {
 }
 
 func TestBookService_ListBookshelf(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		bookshelves []*book.Bookshelf
+		err         error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Bookshelves []*book.Bookshelf
-			Error       error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Bookshelves []*book.Bookshelf
-				Error       error
-			}{
-				Bookshelves: []*book.Bookshelf{
+			want: want{
+				bookshelves: []*book.Bookshelf{
 					{
 						ID:        0,
 						BookID:    1,
@@ -112,13 +120,13 @@ func TestBookService_ListBookshelf(t *testing.T) {
 						UpdatedAt: time.Time{},
 					},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -128,19 +136,19 @@ func TestBookService_ListBookshelf(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ListBookshelf(ctx, tc.Query).Return(tc.Expected.Bookshelves, tc.Expected.Error)
+			brm.EXPECT().ListBookshelf(ctx, tc.args.query).Return(tc.want.bookshelves, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ListBookshelf(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				bookshelves, err := target.ListBookshelf(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Bookshelves) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Bookshelves, got)
+				if !reflect.DeepEqual(bookshelves, tc.want.bookshelves) {
+					t.Fatalf("want %#v, but %#v", tc.want.bookshelves, bookshelves)
 					return
 				}
 			})
@@ -149,25 +157,29 @@ func TestBookService_ListBookshelf(t *testing.T) {
 }
 
 func TestBookService_ListReview(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		reviews []*book.Review
+		err     error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Reviews []*book.Review
-			Error   error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Reviews []*book.Review
-				Error   error
-			}{
-				Reviews: []*book.Review{
+			want: want{
+				reviews: []*book.Review{
 					{
 						ID:         1,
 						BookID:     1,
@@ -178,13 +190,13 @@ func TestBookService_ListReview(t *testing.T) {
 						UpdatedAt:  time.Time{},
 					},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -194,19 +206,19 @@ func TestBookService_ListReview(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ListReview(ctx, tc.Query).Return(tc.Expected.Reviews, tc.Expected.Error)
+			brm.EXPECT().ListReview(ctx, tc.args.query).Return(tc.want.reviews, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ListReview(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				reviews, err := target.ListReview(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Reviews) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Reviews, got)
+				if !reflect.DeepEqual(reviews, tc.want.reviews) {
+					t.Fatalf("want %#v, but %#v", tc.want.reviews, reviews)
 					return
 				}
 			})
@@ -215,32 +227,36 @@ func TestBookService_ListReview(t *testing.T) {
 }
 
 func TestUserService_ListCount(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		count int
+		err   error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Count int
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Count int
-				Error error
-			}{
-				Count: 1,
-				Error: nil,
+			want: want{
+				count: 1,
+				err:   nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -250,19 +266,19 @@ func TestUserService_ListCount(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ListCount(ctx, tc.Query).Return(tc.Expected.Count, tc.Expected.Error)
+			brm.EXPECT().ListCount(ctx, tc.args.query).Return(tc.want.count, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ListCount(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				count, err := target.ListCount(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Count) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Count, got)
+				if !reflect.DeepEqual(count, tc.want.count) {
+					t.Fatalf("want %#v, but %#v", tc.want.count, count)
 					return
 				}
 			})
@@ -271,32 +287,36 @@ func TestUserService_ListCount(t *testing.T) {
 }
 
 func TestUserService_ListBookshelfCount(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		count int
+		err   error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Count int
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Count int
-				Error error
-			}{
-				Count: 1,
-				Error: nil,
+			want: want{
+				count: 1,
+				err:   nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -306,19 +326,19 @@ func TestUserService_ListBookshelfCount(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ListBookshelfCount(ctx, tc.Query).Return(tc.Expected.Count, tc.Expected.Error)
+			brm.EXPECT().ListBookshelfCount(ctx, tc.args.query).Return(tc.want.count, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ListBookshelfCount(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				count, err := target.ListBookshelfCount(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Count) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Count, got)
+				if !reflect.DeepEqual(count, tc.want.count) {
+					t.Fatalf("want %#v, but %#v", tc.want.count, count)
 					return
 				}
 			})
@@ -327,32 +347,36 @@ func TestUserService_ListBookshelfCount(t *testing.T) {
 }
 
 func TestUserService_ListReviewCount(t *testing.T) {
+	type args struct {
+		query *domain.ListQuery
+	}
+	type want struct {
+		count int
+		err   error
+	}
+
 	testCases := map[string]struct {
-		Query    *domain.ListQuery
-		Expected struct {
-			Count int
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Query: &domain.ListQuery{
-				Limit:      100,
-				Offset:     0,
-				Order:      nil,
-				Conditions: []*domain.QueryCondition{},
+			args: args{
+				query: &domain.ListQuery{
+					Limit:      100,
+					Offset:     0,
+					Order:      nil,
+					Conditions: []*domain.QueryCondition{},
+				},
 			},
-			Expected: struct {
-				Count int
-				Error error
-			}{
-				Count: 1,
-				Error: nil,
+			want: want{
+				count: 1,
+				err:   nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -362,19 +386,19 @@ func TestUserService_ListReviewCount(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ListReviewCount(ctx, tc.Query).Return(tc.Expected.Count, tc.Expected.Error)
+			brm.EXPECT().ListReviewCount(ctx, tc.args.query).Return(tc.want.count, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ListReviewCount(ctx, tc.Query)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				count, err := target.ListReviewCount(ctx, tc.args.query)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Count) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Count, got)
+				if !reflect.DeepEqual(count, tc.want.count) {
+					t.Fatalf("want %#v, but %#v", tc.want.count, count)
 					return
 				}
 			})
@@ -383,20 +407,24 @@ func TestUserService_ListReviewCount(t *testing.T) {
 }
 
 func TestBookService_Show(t *testing.T) {
+	type args struct {
+		bookID int
+	}
+	type want struct {
+		book *book.Book
+		err  error
+	}
+
 	testCases := map[string]struct {
-		BookID   int
-		Expected struct {
-			Book  *book.Book
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			BookID: 1,
-			Expected: struct {
-				Book  *book.Book
-				Error error
-			}{
-				Book: &book.Book{
+			args: args{
+				bookID: 1,
+			},
+			want: want{
+				book: &book.Book{
 					ID:           1,
 					Title:        "テスト書籍",
 					TitleKana:    "てすとしょせき",
@@ -405,18 +433,14 @@ func TestBookService_Show(t *testing.T) {
 					Publisher:    "テスト著者",
 					PublishedOn:  "2021年12月24日",
 					ThumbnailURL: "",
-					CreatedAt:    time.Time{},
-					UpdatedAt:    time.Time{},
-					Authors:      []*book.Author{},
-					Reviews:      []*book.Review{},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -426,19 +450,19 @@ func TestBookService_Show(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().Show(ctx, tc.BookID).Return(tc.Expected.Book, tc.Expected.Error)
+			brm.EXPECT().Show(ctx, tc.want.book.ID).Return(tc.want.book, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.Show(ctx, tc.BookID)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				book, err := target.Show(ctx, tc.args.bookID)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Book) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Book, got)
+				if !reflect.DeepEqual(book, tc.want.book) {
+					t.Fatalf("want %#v, but %#v", tc.want.book, book)
 					return
 				}
 			})
@@ -447,20 +471,24 @@ func TestBookService_Show(t *testing.T) {
 }
 
 func TestBookService_ShowByIsbn(t *testing.T) {
+	type args struct {
+		isbn string
+	}
+	type want struct {
+		book *book.Book
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Isbn     string
-		Expected struct {
-			Book  *book.Book
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Isbn: "978-1-234-56789-7",
-			Expected: struct {
-				Book  *book.Book
-				Error error
-			}{
-				Book: &book.Book{
+			args: args{
+				isbn: "978-1-234-56789-7",
+			},
+			want: want{
+				book: &book.Book{
 					ID:           1,
 					Title:        "テスト書籍",
 					TitleKana:    "てすとしょせき",
@@ -469,18 +497,14 @@ func TestBookService_ShowByIsbn(t *testing.T) {
 					Publisher:    "テスト著者",
 					PublishedOn:  "2021年12月24日",
 					ThumbnailURL: "",
-					CreatedAt:    time.Time{},
-					UpdatedAt:    time.Time{},
-					Authors:      []*book.Author{},
-					Reviews:      []*book.Review{},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -490,19 +514,19 @@ func TestBookService_ShowByIsbn(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ShowByIsbn(ctx, tc.Isbn).Return(tc.Expected.Book, tc.Expected.Error)
+			brm.EXPECT().ShowByIsbn(ctx, tc.args.isbn).Return(tc.want.book, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ShowByIsbn(ctx, tc.Isbn)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				book, err := target.ShowByIsbn(ctx, tc.args.isbn)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Book) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Book, got)
+				if !reflect.DeepEqual(book, tc.want.book) {
+					t.Fatalf("want %#v, but %#v", tc.want.book, book)
 					return
 				}
 			})
@@ -511,36 +535,38 @@ func TestBookService_ShowByIsbn(t *testing.T) {
 }
 
 func TestBookService_ShowBookshelfByUserIDAndBookID(t *testing.T) {
+	type args struct {
+		userID string
+		bookID int
+	}
+	type want struct {
+		bookshelf *book.Bookshelf
+		err       error
+	}
+
 	testCases := map[string]struct {
-		UserID   string
-		BookID   int
-		Expected struct {
-			Bookshelf *book.Bookshelf
-			Error     error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UserID: "00000000-0000-0000-0000-000000000000",
-			BookID: 1,
-			Expected: struct {
-				Bookshelf *book.Bookshelf
-				Error     error
-			}{
-				Bookshelf: &book.Bookshelf{
-					ID:        0,
-					BookID:    1,
-					UserID:    "00000000-0000-0000-0000-000000000000",
-					Status:    5,
-					CreatedAt: time.Time{},
-					UpdatedAt: time.Time{},
+			args: args{
+				userID: "00000000-0000-0000-0000-000000000000",
+				bookID: 1,
+			},
+			want: want{
+				bookshelf: &book.Bookshelf{
+					ID:     1,
+					BookID: 1,
+					UserID: "00000000-0000-0000-0000-000000000000",
+					Status: 5,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -551,20 +577,20 @@ func TestBookService_ShowBookshelfByUserIDAndBookID(t *testing.T) {
 
 			brm := mock_book.NewMockRepository(ctrl)
 			brm.EXPECT().
-				ShowBookshelfByUserIDAndBookID(ctx, tc.UserID, tc.BookID).
-				Return(tc.Expected.Bookshelf, tc.Expected.Error)
+				ShowBookshelfByUserIDAndBookID(ctx, tc.args.userID, tc.args.bookID).
+				Return(tc.want.bookshelf, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ShowBookshelfByUserIDAndBookID(ctx, tc.UserID, tc.BookID)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				bookshelf, err := target.ShowBookshelfByUserIDAndBookID(ctx, tc.args.userID, tc.args.bookID)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Bookshelf) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Bookshelf, got)
+				if !reflect.DeepEqual(bookshelf, tc.want.bookshelf) {
+					t.Fatalf("want %#v, but %#v", tc.want.bookshelf, bookshelf)
 					return
 				}
 			})
@@ -573,34 +599,37 @@ func TestBookService_ShowBookshelfByUserIDAndBookID(t *testing.T) {
 }
 
 func TestBookService_ShowReview(t *testing.T) {
+	type args struct {
+		reviewID int
+	}
+	type want struct {
+		review *book.Review
+		err    error
+	}
+
 	testCases := map[string]struct {
-		ReviewID int
-		Expected struct {
-			Review *book.Review
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			ReviewID: 1,
-			Expected: struct {
-				Review *book.Review
-				Error  error
-			}{
-				Review: &book.Review{
+			args: args{
+				reviewID: 1,
+			},
+			want: want{
+				review: &book.Review{
 					ID:         1,
 					BookID:     1,
 					UserID:     "00000000-0000-0000-0000-000000000000",
 					Score:      1,
 					Impression: "読んだ感想です。",
-					CreatedAt:  time.Time{},
-					UpdatedAt:  time.Time{},
 				},
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -610,19 +639,19 @@ func TestBookService_ShowReview(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().ShowReview(ctx, tc.ReviewID).Return(tc.Expected.Review, tc.Expected.Error)
+			brm.EXPECT().ShowReview(ctx, tc.args.reviewID).Return(tc.want.review, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ShowReview(ctx, tc.ReviewID)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				review, err := target.ShowReview(ctx, tc.args.reviewID)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Review) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Review, got)
+				if !reflect.DeepEqual(review, tc.want.review) {
+					t.Fatalf("want %#v, but %#v", tc.want.review, review)
 					return
 				}
 			})
@@ -631,36 +660,39 @@ func TestBookService_ShowReview(t *testing.T) {
 }
 
 func TestBookService_ShowReviewByUserIDAndBookID(t *testing.T) {
+	type args struct {
+		userID string
+		bookID int
+	}
+	type want struct {
+		review *book.Review
+		err    error
+	}
+
 	testCases := map[string]struct {
-		UserID   string
-		BookID   int
-		Expected struct {
-			Review *book.Review
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UserID: "00000000-0000-0000-0000-000000000000",
-			BookID: 1,
-			Expected: struct {
-				Review *book.Review
-				Error  error
-			}{
-				Review: &book.Review{
-					ID:         0,
+			args: args{
+				userID: "00000000-0000-0000-0000-000000000000",
+				bookID: 1,
+			},
+			want: want{
+				review: &book.Review{
+					ID:         1,
 					BookID:     1,
 					UserID:     "00000000-0000-0000-0000-000000000000",
 					Score:      1,
 					Impression: "読んだ感想です。",
-					CreatedAt:  time.Time{},
-					UpdatedAt:  time.Time{},
 				},
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -671,20 +703,20 @@ func TestBookService_ShowReviewByUserIDAndBookID(t *testing.T) {
 
 			brm := mock_book.NewMockRepository(ctrl)
 			brm.EXPECT().
-				ShowReviewByUserIDAndBookID(ctx, tc.UserID, tc.BookID).
-				Return(tc.Expected.Review, tc.Expected.Error)
+				ShowReviewByUserIDAndBookID(ctx, tc.args.userID, tc.args.bookID).
+				Return(tc.want.review, tc.want.err)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				got, err := target.ShowReviewByUserIDAndBookID(ctx, tc.UserID, tc.BookID)
-				if !reflect.DeepEqual(err, tc.Expected.Error) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+				review, err := target.ShowReviewByUserIDAndBookID(ctx, tc.args.userID, tc.args.bookID)
+				if !reflect.DeepEqual(err, tc.want.err) {
+					t.Fatalf("want %#v, but %#v", tc.want.err, err)
 					return
 				}
 
-				if !reflect.DeepEqual(got, tc.Expected.Review) {
-					t.Fatalf("want %#v, but %#v", tc.Expected.Review, got)
+				if !reflect.DeepEqual(review, tc.want.review) {
+					t.Fatalf("want %#v, but %#v", tc.want.review, review)
 					return
 				}
 			})
@@ -693,28 +725,34 @@ func TestBookService_ShowReviewByUserIDAndBookID(t *testing.T) {
 }
 
 func TestBookService_Create(t *testing.T) {
+	type args struct {
+		book *book.Book
+	}
+
 	testCases := map[string]struct {
-		Book     *book.Book
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Book: &book.Book{
-				Title:        "テスト書籍",
-				TitleKana:    "てすとしょせき",
-				Description:  "本の説明です",
-				Isbn:         "1234567890123",
-				Publisher:    "テスト著者",
-				PublishedOn:  "2021年12月24日",
-				ThumbnailURL: "",
-				Authors:      []*book.Author{},
-				Reviews:      []*book.Review{},
+			args: args{
+				book: &book.Book{
+					Title:        "テスト書籍",
+					TitleKana:    "てすとしょせき",
+					Description:  "本の説明です",
+					Isbn:         "1234567890123",
+					Publisher:    "テスト著者",
+					PublishedOn:  "2021年12月24日",
+					ThumbnailURL: "",
+					Authors:      []*book.Author{},
+					Reviews:      []*book.Review{},
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -724,26 +762,26 @@ func TestBookService_Create(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().Create(ctx, tc.Book).Return(tc.Expected)
-			for _, a := range tc.Book.Authors {
-				brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(tc.Expected)
+			brm.EXPECT().Create(ctx, tc.args.book).Return(tc.want)
+			for _, a := range tc.args.book.Authors {
+				brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(nil)
 			}
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.Create(ctx, tc.Book)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Create(ctx, tc.args.book)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 
-				if tc.Book.CreatedAt.IsZero() {
+				if tc.args.book.CreatedAt.IsZero() {
 					t.Fatal("CreatedAt must be not null")
 					return
 				}
 
-				if tc.Book.UpdatedAt.IsZero() {
+				if tc.args.book.UpdatedAt.IsZero() {
 					t.Fatal("UpdatedAt must be not null")
 					return
 				}
@@ -753,22 +791,28 @@ func TestBookService_Create(t *testing.T) {
 }
 
 func TestBookService_CreateBookshelf(t *testing.T) {
+	type args struct {
+		bookshelf *book.Bookshelf
+	}
+
 	testCases := map[string]struct {
-		Bookshelf *book.Bookshelf
-		Expected  error
+		args args
+		want error
 	}{
 		"ok": {
-			Bookshelf: &book.Bookshelf{
-				BookID: 1,
-				UserID: "00000000-0000-0000-0000-000000000000",
-				Status: 5,
+			args: args{
+				bookshelf: &book.Bookshelf{
+					BookID: 1,
+					UserID: "00000000-0000-0000-0000-000000000000",
+					Status: 5,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -778,23 +822,23 @@ func TestBookService_CreateBookshelf(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().CreateBookshelf(ctx, tc.Bookshelf).Return(tc.Expected)
+			brm.EXPECT().CreateBookshelf(ctx, tc.args.bookshelf).Return(tc.want)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.CreateBookshelf(ctx, tc.Bookshelf)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.CreateBookshelf(ctx, tc.args.bookshelf)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 
-				if tc.Bookshelf.CreatedAt.IsZero() {
+				if tc.args.bookshelf.CreatedAt.IsZero() {
 					t.Fatal("CreatedAt must be not null")
 					return
 				}
 
-				if tc.Bookshelf.UpdatedAt.IsZero() {
+				if tc.args.bookshelf.UpdatedAt.IsZero() {
 					t.Fatal("UpdatedAt must be not null")
 					return
 				}
@@ -804,32 +848,37 @@ func TestBookService_CreateBookshelf(t *testing.T) {
 }
 
 func TestBookService_Update(t *testing.T) {
+	type args struct {
+		book *book.Book
+	}
+
 	testCases := map[string]struct {
-		Book     *book.Book
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Book: &book.Book{
-				ID:           1,
-				Title:        "テスト書籍",
-				Description:  "本の説明",
-				Isbn:         "978-1-234-56789-7",
-				ThumbnailURL: "",
-				Publisher:    "テスト出版社",
-				PublishedOn:  "2021年12月24日",
-				Reviews:      []*book.Review{},
-				Authors: []*book.Author{{
-					ID:       1,
-					Name:     "テスト著者",
-					NameKana: "てすとちょしゃ",
-				}},
+			args: args{
+				book: &book.Book{
+					ID:           1,
+					Title:        "テスト書籍",
+					Description:  "本の説明",
+					Isbn:         "978-1-234-56789-7",
+					ThumbnailURL: "",
+					Publisher:    "テスト出版社",
+					PublishedOn:  "2021年12月24日",
+					Authors: []*book.Author{{
+						ID:       1,
+						Name:     "テスト著者",
+						NameKana: "てすとちょしゃ",
+					}},
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -839,21 +888,21 @@ func TestBookService_Update(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().Update(ctx, tc.Book).Return(tc.Expected)
-			for _, a := range tc.Book.Authors {
-				brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(tc.Expected)
+			brm.EXPECT().Update(ctx, tc.args.book).Return(tc.want)
+			for _, a := range tc.args.book.Authors {
+				brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(nil)
 			}
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.Update(ctx, tc.Book)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Update(ctx, tc.args.book)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 
-				if tc.Book.UpdatedAt.IsZero() {
+				if tc.args.book.UpdatedAt.IsZero() {
 					t.Fatal("UpdatedAt must be not null")
 					return
 				}
@@ -863,23 +912,29 @@ func TestBookService_Update(t *testing.T) {
 }
 
 func TestBookService_UpdateBookshelf(t *testing.T) {
+	type args struct {
+		bookshelf *book.Bookshelf
+	}
+
 	testCases := map[string]struct {
-		Bookshelf *book.Bookshelf
-		Expected  error
+		args args
+		want error
 	}{
 		"ok": {
-			Bookshelf: &book.Bookshelf{
-				ID:     1,
-				BookID: 1,
-				UserID: "00000000-0000-0000-0000-000000000000",
-				Status: 5,
+			args: args{
+				bookshelf: &book.Bookshelf{
+					ID:     1,
+					BookID: 1,
+					UserID: "00000000-0000-0000-0000-000000000000",
+					Status: 5,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -889,18 +944,18 @@ func TestBookService_UpdateBookshelf(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().UpdateBookshelf(ctx, tc.Bookshelf).Return(tc.Expected)
+			brm.EXPECT().UpdateBookshelf(ctx, tc.args.bookshelf).Return(tc.want)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.UpdateBookshelf(ctx, tc.Bookshelf)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.UpdateBookshelf(ctx, tc.args.bookshelf)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 
-				if tc.Bookshelf.UpdatedAt.IsZero() {
+				if tc.args.bookshelf.UpdatedAt.IsZero() {
 					t.Fatal("UpdatedAt must be not null")
 					return
 				}
@@ -910,30 +965,34 @@ func TestBookService_UpdateBookshelf(t *testing.T) {
 }
 
 func TestBookService_MultipleCreate(t *testing.T) {
+	type args struct {
+		books []*book.Book
+	}
+
 	testCases := map[string]struct {
-		Books    []*book.Book
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Books: []*book.Book{
-				{
-					Title:        "テスト書籍",
-					TitleKana:    "てすとしょせき",
-					Description:  "本の説明です",
-					Isbn:         "1234567890123",
-					Publisher:    "テスト著者",
-					PublishedOn:  "2021年12月24日",
-					ThumbnailURL: "",
-					Authors:      []*book.Author{},
-					Reviews:      []*book.Review{},
+			args: args{
+				books: []*book.Book{
+					{
+						Title:        "テスト書籍",
+						TitleKana:    "てすとしょせき",
+						Description:  "本の説明です",
+						Isbn:         "1234567890123",
+						Publisher:    "テスト著者",
+						PublishedOn:  "2021年12月24日",
+						ThumbnailURL: "",
+					},
 				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -943,23 +1002,23 @@ func TestBookService_MultipleCreate(t *testing.T) {
 			bvm := mock_book.NewMockValidation(ctrl)
 
 			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().MultipleCreate(ctx, tc.Books).Return(tc.Expected)
-			for _, b := range tc.Books {
+			brm.EXPECT().MultipleCreate(ctx, tc.args.books).Return(tc.want)
+			for _, b := range tc.args.books {
 				for _, a := range b.Authors {
-					brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(tc.Expected)
+					brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(nil)
 				}
 			}
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.MultipleCreate(ctx, tc.Books)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.MultipleCreate(ctx, tc.args.books)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 
-				for _, v := range tc.Books {
+				for _, v := range tc.args.books {
 					if v.CreatedAt.IsZero() {
 						t.Fatal("CreatedAt must be not null")
 						return
@@ -976,15 +1035,179 @@ func TestBookService_MultipleCreate(t *testing.T) {
 }
 
 func TestBookService_MultipleUpdate(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		books []*book.Book
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Books    []*book.Book
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Books: []*book.Book{
-				{
+			args: args{
+				books: []*book.Book{
+					{
+						ID:           1,
+						Title:        "テスト書籍",
+						Description:  "本の説明",
+						Isbn:         "978-1-234-56789-7",
+						ThumbnailURL: "",
+						Publisher:    "テスト出版社",
+						PublishedOn:  "2021年12月24日",
+						CreatedAt:    current,
+						UpdatedAt:    current,
+						Authors: []*book.Author{{
+							ID:        1,
+							Name:      "テスト著者",
+							NameKana:  "てすとちょしゃ",
+							CreatedAt: current,
+							UpdatedAt: current,
+						}},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			bvm := mock_book.NewMockValidation(ctrl)
+
+			brm := mock_book.NewMockRepository(ctrl)
+			brm.EXPECT().MultipleUpdate(ctx, tc.args.books).Return(tc.want)
+			for _, b := range tc.args.books {
+				for _, a := range b.Authors {
+					brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(nil)
+				}
+			}
+
+			t.Run(name, func(t *testing.T) {
+				target := NewBookService(bvm, brm)
+
+				err := target.MultipleUpdate(ctx, tc.args.books)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
+					return
+				}
+
+				for _, v := range tc.args.books {
+					if v.UpdatedAt.IsZero() {
+						t.Fatal("UpdatedAt must be not null")
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestBookService_Delete(t *testing.T) {
+	type args struct {
+		bookID int
+	}
+
+	testCases := map[string]struct {
+		args args
+		want error
+	}{
+		"ok": {
+			args: args{
+				bookID: 1,
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			bvm := mock_book.NewMockValidation(ctrl)
+
+			brm := mock_book.NewMockRepository(ctrl)
+			brm.EXPECT().Delete(ctx, tc.args.bookID).Return(tc.want)
+
+			t.Run(name, func(t *testing.T) {
+				target := NewBookService(bvm, brm)
+
+				err := target.Delete(ctx, tc.args.bookID)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
+					return
+				}
+			})
+		})
+	}
+}
+
+func TestBookService_DeleteBookshelf(t *testing.T) {
+	type args struct {
+		bookshelfID int
+	}
+
+	testCases := map[string]struct {
+		args args
+		want error
+	}{
+		"ok": {
+			args: args{
+				bookshelfID: 1,
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			bvm := mock_book.NewMockValidation(ctrl)
+
+			brm := mock_book.NewMockRepository(ctrl)
+			brm.EXPECT().DeleteBookshelf(ctx, tc.args.bookshelfID).Return(tc.want)
+
+			t.Run(name, func(t *testing.T) {
+				target := NewBookService(bvm, brm)
+
+				err := target.DeleteBookshelf(ctx, tc.args.bookshelfID)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
+					return
+				}
+			})
+		})
+	}
+}
+
+func TestBookService_Validation(t *testing.T) {
+	type args struct {
+		book *book.Book
+	}
+
+	current := time.Now().Local()
+	testCases := map[string]struct {
+		args args
+		want error
+	}{
+		"ok": {
+			args: args{
+				book: &book.Book{
 					ID:           1,
 					Title:        "テスト書籍",
 					Description:  "本の説明",
@@ -1004,12 +1227,12 @@ func TestBookService_MultipleUpdate(t *testing.T) {
 					}},
 				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -1017,159 +1240,16 @@ func TestBookService_MultipleUpdate(t *testing.T) {
 			defer ctrl.Finish()
 
 			bvm := mock_book.NewMockValidation(ctrl)
-
-			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().MultipleUpdate(ctx, tc.Books).Return(tc.Expected)
-			for _, b := range tc.Books {
-				for _, a := range b.Authors {
-					brm.EXPECT().ShowOrCreateAuthor(ctx, a).Return(tc.Expected)
-				}
-			}
-
-			t.Run(result, func(t *testing.T) {
-				target := NewBookService(bvm, brm)
-
-				err := target.MultipleUpdate(ctx, tc.Books)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
-					return
-				}
-
-				for _, v := range tc.Books {
-					if v.UpdatedAt.IsZero() {
-						t.Fatal("UpdatedAt must be not null")
-						return
-					}
-				}
-			})
-		})
-	}
-}
-
-func TestBookService_Delete(t *testing.T) {
-	testCases := map[string]struct {
-		BookID   int
-		Expected error
-	}{
-		"ok": {
-			BookID:   1,
-			Expected: nil,
-		},
-	}
-
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			bvm := mock_book.NewMockValidation(ctrl)
-
-			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().Delete(ctx, tc.BookID).Return(tc.Expected)
-
-			t.Run(result, func(t *testing.T) {
-				target := NewBookService(bvm, brm)
-
-				err := target.Delete(ctx, tc.BookID)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
-					return
-				}
-			})
-		})
-	}
-}
-
-func TestBookService_DeleteBookshelf(t *testing.T) {
-	testCases := map[string]struct {
-		BookshelfID int
-		Expected    error
-	}{
-		"ok": {
-			BookshelfID: 1,
-			Expected:    nil,
-		},
-	}
-
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			bvm := mock_book.NewMockValidation(ctrl)
-
-			brm := mock_book.NewMockRepository(ctrl)
-			brm.EXPECT().DeleteBookshelf(ctx, tc.BookshelfID).Return(tc.Expected)
-
-			t.Run(result, func(t *testing.T) {
-				target := NewBookService(bvm, brm)
-
-				err := target.DeleteBookshelf(ctx, tc.BookshelfID)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
-					return
-				}
-			})
-		})
-	}
-}
-
-func TestBookService_Validation(t *testing.T) {
-	current := time.Now()
-
-	testCases := map[string]struct {
-		Book     *book.Book
-		Expected error
-	}{
-		"ok": {
-			Book: &book.Book{
-				ID:           1,
-				Title:        "テスト書籍",
-				Description:  "本の説明",
-				Isbn:         "978-1-234-56789-7",
-				ThumbnailURL: "",
-				Publisher:    "テスト出版社",
-				PublishedOn:  "2021年12月24日",
-				CreatedAt:    current,
-				UpdatedAt:    current,
-				Reviews:      []*book.Review{},
-				Authors: []*book.Author{{
-					ID:        1,
-					Name:      "テスト著者",
-					NameKana:  "てすとちょしゃ",
-					CreatedAt: current,
-					UpdatedAt: current,
-				}},
-			},
-			Expected: nil,
-		},
-	}
-
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			bvm := mock_book.NewMockValidation(ctrl)
-			bvm.EXPECT().Book(ctx, tc.Book).Return(tc.Expected)
+			bvm.EXPECT().Book(ctx, tc.args.book).Return(tc.want)
 
 			brm := mock_book.NewMockRepository(ctrl)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.Validation(ctx, tc.Book)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Validation(ctx, tc.args.book)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -1178,20 +1258,29 @@ func TestBookService_Validation(t *testing.T) {
 }
 
 func TestBookService_ValidationAuthor(t *testing.T) {
+	type args struct {
+		author *book.Author
+	}
+
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Author   *book.Author
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Author: &book.Author{
-				Name: "テスト著者",
+			args: args{
+				author: &book.Author{
+					Name:      "テスト著者",
+					CreatedAt: current,
+					UpdatedAt: current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -1199,16 +1288,16 @@ func TestBookService_ValidationAuthor(t *testing.T) {
 			defer ctrl.Finish()
 
 			bvm := mock_book.NewMockValidation(ctrl)
-			bvm.EXPECT().Author(ctx, tc.Author).Return(tc.Expected)
+			bvm.EXPECT().Author(ctx, tc.args.author).Return(tc.want)
 
 			brm := mock_book.NewMockRepository(ctrl)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.ValidationAuthor(ctx, tc.Author)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.ValidationAuthor(ctx, tc.args.author)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -1217,25 +1306,32 @@ func TestBookService_ValidationAuthor(t *testing.T) {
 }
 
 func TestBookService_ValidationBookshelf(t *testing.T) {
+	type args struct {
+		bookshelf *book.Bookshelf
+	}
+
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Bookshelf *book.Bookshelf
-		Expected  error
+		args args
+		want error
 	}{
 		"ok": {
-			Bookshelf: &book.Bookshelf{
-				ID:        0,
-				BookID:    1,
-				UserID:    "00000000-0000-0000-0000-000000000000",
-				Status:    5,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+			args: args{
+				bookshelf: &book.Bookshelf{
+					ID:        0,
+					BookID:    1,
+					UserID:    "00000000-0000-0000-0000-000000000000",
+					Status:    5,
+					CreatedAt: current,
+					UpdatedAt: current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -1243,16 +1339,16 @@ func TestBookService_ValidationBookshelf(t *testing.T) {
 			defer ctrl.Finish()
 
 			bvm := mock_book.NewMockValidation(ctrl)
-			bvm.EXPECT().Bookshelf(ctx, tc.Bookshelf).Return(tc.Expected)
+			bvm.EXPECT().Bookshelf(ctx, tc.args.bookshelf).Return(tc.want)
 
 			brm := mock_book.NewMockRepository(ctrl)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.ValidationBookshelf(ctx, tc.Bookshelf)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.ValidationBookshelf(ctx, tc.args.bookshelf)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -1261,26 +1357,33 @@ func TestBookService_ValidationBookshelf(t *testing.T) {
 }
 
 func TestBookService_ValidationReview(t *testing.T) {
+	type args struct {
+		review *book.Review
+	}
+
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Review   *book.Review
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Review: &book.Review{
-				ID:         0,
-				BookID:     1,
-				UserID:     "00000000-0000-0000-0000-000000000000",
-				Score:      5,
-				Impression: "書籍の感想です。",
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
+			args: args{
+				review: &book.Review{
+					ID:         0,
+					BookID:     1,
+					UserID:     "00000000-0000-0000-0000-000000000000",
+					Score:      5,
+					Impression: "書籍の感想です。",
+					CreatedAt:  current,
+					UpdatedAt:  current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -1288,16 +1391,16 @@ func TestBookService_ValidationReview(t *testing.T) {
 			defer ctrl.Finish()
 
 			bvm := mock_book.NewMockValidation(ctrl)
-			bvm.EXPECT().Review(ctx, tc.Review).Return(tc.Expected)
+			bvm.EXPECT().Review(ctx, tc.args.review).Return(tc.want)
 
 			brm := mock_book.NewMockRepository(ctrl)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookService(bvm, brm)
 
-				err := target.ValidationReview(ctx, tc.Review)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.ValidationReview(ctx, tc.args.review)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})

--- a/api/server/book/internal/infrastructure/validation/book_test.go
+++ b/api/server/book/internal/infrastructure/validation/book_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/calmato/gran-book/api/server/book/internal/domain/book"
 	"github.com/calmato/gran-book/api/server/book/lib/datetime"
@@ -13,31 +12,32 @@ import (
 )
 
 func TestBookService_Book(t *testing.T) {
+	type args struct {
+		book *book.Book
+	}
+
 	testCases := map[string]struct {
-		Book     *book.Book
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Book: &book.Book{
-				ID:           0,
-				Title:        "テスト書籍",
-				TitleKana:    "てすとしょせき",
-				Description:  "本の説明です",
-				Isbn:         "1234567890123",
-				Publisher:    "テスト著者",
-				PublishedOn:  "2021年12月24日",
-				ThumbnailURL: "",
-				CreatedAt:    time.Time{},
-				UpdatedAt:    time.Time{},
-				Authors:      []*book.Author{},
-				Reviews:      []*book.Review{},
+			args: args{
+				book: &book.Book{
+					Title:        "テスト書籍",
+					TitleKana:    "てすとしょせき",
+					Description:  "本の説明です",
+					Isbn:         "1234567890123",
+					Publisher:    "テスト著者",
+					PublishedOn:  "2021年12月24日",
+					ThumbnailURL: "",
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -45,14 +45,14 @@ func TestBookService_Book(t *testing.T) {
 			defer ctrl.Finish()
 
 			bvm := mock_book.NewMockRepository(ctrl)
-			bvm.EXPECT().GetIDByIsbn(ctx, tc.Book.Isbn).Return(tc.Book.ID, nil)
+			bvm.EXPECT().GetIDByIsbn(ctx, tc.args.book.Isbn).Return(tc.args.book.ID, nil)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookDomainValidation(bvm)
 
-				err := target.Book(ctx, tc.Book)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Book(ctx, tc.args.book)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -61,24 +61,27 @@ func TestBookService_Book(t *testing.T) {
 }
 
 func TestBookService_Author(t *testing.T) {
+	type args struct {
+		author *book.Author
+	}
+
 	testCases := map[string]struct {
-		Author   *book.Author
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Author: &book.Author{
-				ID:        0,
-				Name:      "テスト著者",
-				NameKana:  "てすとちょしゃ",
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+			args: args{
+				author: &book.Author{
+					Name:     "テスト著者",
+					NameKana: "てすとちょしゃ",
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -87,12 +90,12 @@ func TestBookService_Author(t *testing.T) {
 
 			bvm := mock_book.NewMockRepository(ctrl)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookDomainValidation(bvm)
 
-				err := target.Author(ctx, tc.Author)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Author(ctx, tc.args.author)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -101,26 +104,29 @@ func TestBookService_Author(t *testing.T) {
 }
 
 func TestBookService_Bookshelf(t *testing.T) {
+	type args struct {
+		bookshelf *book.Bookshelf
+	}
+
 	testCases := map[string]struct {
-		Bookshelf *book.Bookshelf
-		Expected  error
+		args args
+		want error
 	}{
 		"ok": {
-			Bookshelf: &book.Bookshelf{
-				ID:        0,
-				BookID:    1,
-				UserID:    "00000000-0000-0000-0000-000000000000",
-				Status:    5,
-				ReadOn:    datetime.StringToDate("2020-01-01"),
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+			args: args{
+				bookshelf: &book.Bookshelf{
+					BookID: 1,
+					UserID: "00000000-0000-0000-0000-000000000000",
+					Status: 5,
+					ReadOn: datetime.StringToDate("2020-01-01"),
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -129,15 +135,15 @@ func TestBookService_Bookshelf(t *testing.T) {
 
 			bvm := mock_book.NewMockRepository(ctrl)
 			bvm.EXPECT().
-				GetBookshelfIDByUserIDAndBookID(ctx, tc.Bookshelf.UserID, tc.Bookshelf.BookID).
-				Return(tc.Bookshelf.ID, nil)
+				GetBookshelfIDByUserIDAndBookID(ctx, tc.args.bookshelf.UserID, tc.args.bookshelf.BookID).
+				Return(tc.args.bookshelf.ID, nil)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookDomainValidation(bvm)
 
-				err := target.Bookshelf(ctx, tc.Bookshelf)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Bookshelf(ctx, tc.args.bookshelf)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})
@@ -146,26 +152,29 @@ func TestBookService_Bookshelf(t *testing.T) {
 }
 
 func TestBookService_Review(t *testing.T) {
+	type args struct {
+		review *book.Review
+	}
+
 	testCases := map[string]struct {
-		Review   *book.Review
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Review: &book.Review{
-				ID:         0,
-				BookID:     1,
-				UserID:     "00000000-0000-0000-0000-000000000000",
-				Score:      5,
-				Impression: "書籍の感想です。",
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
+			args: args{
+				review: &book.Review{
+					BookID:     1,
+					UserID:     "00000000-0000-0000-0000-000000000000",
+					Score:      5,
+					Impression: "書籍の感想です。",
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
-		t.Run(result, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -174,15 +183,15 @@ func TestBookService_Review(t *testing.T) {
 
 			bvm := mock_book.NewMockRepository(ctrl)
 			bvm.EXPECT().
-				GetReviewIDByUserIDAndBookID(ctx, tc.Review.UserID, tc.Review.BookID).
-				Return(tc.Review.ID, nil)
+				GetReviewIDByUserIDAndBookID(ctx, tc.args.review.UserID, tc.args.review.BookID).
+				Return(tc.args.review.ID, nil)
 
-			t.Run(result, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				target := NewBookDomainValidation(bvm)
 
-				err := target.Review(ctx, tc.Review)
-				if !reflect.DeepEqual(err, tc.Expected) {
-					t.Fatalf("want %#v, but %#v", tc.Expected, err)
+				err := target.Review(ctx, tc.args.review)
+				if !reflect.DeepEqual(err, tc.want) {
+					t.Fatalf("want %#v, but %#v", tc.want, err)
 					return
 				}
 			})

--- a/api/server/information/internal/application/auth_test.go
+++ b/api/server/information/internal/application/auth_test.go
@@ -10,24 +10,23 @@ import (
 )
 
 func TestAuthApplication_Authentication(t *testing.T) {
+	type want struct {
+		uid string
+		err error
+	}
+
 	testCases := map[string]struct {
-		Expected struct {
-			UID   string
-			Error error
-		}
+		want want
 	}{
 		"ok": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "00000000-0000-0000-0000-000000000000",
-				Error: nil,
+			want: want{
+				uid: "00000000-0000-0000-0000-000000000000",
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -35,19 +34,19 @@ func TestAuthApplication_Authentication(t *testing.T) {
 		defer ctrl.Finish()
 
 		asm := mock_auth.NewMockService(ctrl)
-		asm.EXPECT().Authentication(ctx).Return(tc.Expected.UID, tc.Expected.Error)
+		asm.EXPECT().Authentication(ctx).Return(tc.want.uid, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(asm)
 
-			got, err := target.Authentication(ctx)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			uid, err := target.Authentication(ctx)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.UID) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.UID, got)
+			if !reflect.DeepEqual(uid, tc.want.uid) {
+				t.Fatalf("want %#v, but %#v", tc.want.uid, uid)
 				return
 			}
 		})

--- a/api/server/information/internal/infrastructure/service/auth_test.go
+++ b/api/server/information/internal/infrastructure/service/auth_test.go
@@ -11,33 +11,29 @@ import (
 )
 
 func TestAuthService_Authentication(t *testing.T) {
+	type want struct {
+		uid string
+		err error
+	}
+
 	testCases := map[string]struct {
-		Expected struct {
-			UID   string
-			Error error
-		}
+		want want
 	}{
 		"ok": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "00000000-0000-0000-0000-000000000000",
-				Error: nil,
+			want: want{
+				uid: "00000000-0000-0000-0000-000000000000",
+				err: nil,
 			},
 		},
 		"ng_unauthorized": {
-			Expected: struct {
-				UID   string
-				Error error
-			}{
-				UID:   "",
-				Error: exception.Unauthorized.New(nil),
+			want: want{
+				uid: "",
+				err: exception.Unauthorized.New(nil),
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -45,19 +41,19 @@ func TestAuthService_Authentication(t *testing.T) {
 		defer ctrl.Finish()
 
 		arm := mock_auth.NewMockRepository(ctrl)
-		arm.EXPECT().Authentication(ctx).Return(tc.Expected.UID, tc.Expected.Error)
+		arm.EXPECT().Authentication(ctx).Return(tc.want.uid, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthService(arm)
 
 			got, err := target.Authentication(ctx)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.UID) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.UID, got)
+			if !reflect.DeepEqual(got, tc.want.uid) {
+				t.Fatalf("want %#v, but %#v", tc.want.uid, got)
 				return
 			}
 		})

--- a/api/server/information/internal/interface/grpc/v1/error.go
+++ b/api/server/information/internal/interface/grpc/v1/error.go
@@ -1,102 +1,102 @@
-package v1
+// package v1
 
-import (
-	"fmt"
+// import (
+// 	"fmt"
 
-	"github.com/calmato/gran-book/api/server/information/internal/domain/exception"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-)
+// 	"github.com/calmato/gran-book/api/server/information/internal/domain/exception"
+// 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+// 	"google.golang.org/grpc/codes"
+// 	"google.golang.org/grpc/status"
+// )
 
-func errorHandling(e error) error {
-	res := toGRPCError(e)
+// func errorHandling(e error) error {
+// 	res := toGRPCError(e)
 
-	return res
-}
+// 	return res
+// }
 
-func toGRPCError(e error) error {
-	c := getGRPCErrorCode(e)
+// func toGRPCError(e error) error {
+// 	c := getGRPCErrorCode(e)
 
-	st := status.New(c, c.String())
+// 	st := status.New(c, c.String())
 
-	switch c {
-	case codes.InvalidArgument, codes.AlreadyExists:
-		br := &errdetails.BadRequest{
-			FieldViolations: getValidationErrors(e),
-		}
+// 	switch c {
+// 	case codes.InvalidArgument, codes.AlreadyExists:
+// 		br := &errdetails.BadRequest{
+// 			FieldViolations: getValidationErrors(e),
+// 		}
 
-		dt, err := st.WithDetails(br)
-		if err != nil {
-			dt = status.New(codes.Unknown, fmt.Sprintf("Unexpected error attaching metadata: %v", err))
-		}
+// 		dt, err := st.WithDetails(br)
+// 		if err != nil {
+// 			dt = status.New(codes.Unknown, fmt.Sprintf("Unexpected error attaching metadata: %v", err))
+// 		}
 
-		return dt.Err()
-	case codes.Internal:
-		br := &errdetails.LocalizedMessage{
-			Locale:  "en-US",
-			Message: getError(e),
-		}
+// 		return dt.Err()
+// 	case codes.Internal:
+// 		br := &errdetails.LocalizedMessage{
+// 			Locale:  "en-US",
+// 			Message: getError(e),
+// 		}
 
-		dt, err := st.WithDetails(br)
-		if err != nil {
-			dt = status.New(codes.Unknown, fmt.Sprintf("Unexpected error attaching metadata: %v", err))
-		}
+// 		dt, err := st.WithDetails(br)
+// 		if err != nil {
+// 			dt = status.New(codes.Unknown, fmt.Sprintf("Unexpected error attaching metadata: %v", err))
+// 		}
 
-		return dt.Err()
-	default:
-		return st.Err()
-	}
-}
+// 		return dt.Err()
+// 	default:
+// 		return st.Err()
+// 	}
+// }
 
-func getError(e error) string {
-	if err, ok := e.(exception.CustomError); ok {
-		return err.Error()
-	}
+// func getError(e error) string {
+// 	if err, ok := e.(exception.CustomError); ok {
+// 		return err.Error()
+// 	}
 
-	return ""
-}
+// 	return ""
+// }
 
-func getErrorCode(e error) exception.ErrorCode {
-	if err, ok := e.(exception.CustomError); ok {
-		return err.Code()
-	}
+// func getErrorCode(e error) exception.ErrorCode {
+// 	if err, ok := e.(exception.CustomError); ok {
+// 		return err.Code()
+// 	}
 
-	return exception.Unknown
-}
+// 	return exception.Unknown
+// }
 
-func getGRPCErrorCode(e error) codes.Code {
-	switch getErrorCode(e) {
-	case exception.InvalidRequestValidation, exception.UnableConvertBase64:
-		return codes.InvalidArgument
-	case exception.NotFound:
-		return codes.NotFound
-	case exception.Conflict:
-		return codes.AlreadyExists
-	case exception.Forbidden:
-		return codes.PermissionDenied
-	case exception.ErrorInDatastore, exception.ErrorInStorage,
-		exception.ErrorInOtherAPI, exception.InvalidDomainValidation:
-		return codes.Internal
-	case exception.Unauthorized, exception.Expired:
-		return codes.Unauthenticated
-	default:
-		return codes.Unknown
-	}
-}
+// func getGRPCErrorCode(e error) codes.Code {
+// 	switch getErrorCode(e) {
+// 	case exception.InvalidRequestValidation, exception.UnableConvertBase64:
+// 		return codes.InvalidArgument
+// 	case exception.NotFound:
+// 		return codes.NotFound
+// 	case exception.Conflict:
+// 		return codes.AlreadyExists
+// 	case exception.Forbidden:
+// 		return codes.PermissionDenied
+// 	case exception.ErrorInDatastore, exception.ErrorInStorage,
+// 		exception.ErrorInOtherAPI, exception.InvalidDomainValidation:
+// 		return codes.Internal
+// 	case exception.Unauthorized, exception.Expired:
+// 		return codes.Unauthenticated
+// 	default:
+// 		return codes.Unknown
+// 	}
+// }
 
-func getValidationErrors(e error) []*errdetails.BadRequest_FieldViolation {
-	if err, ok := e.(exception.CustomError); ok {
-		ves := make([]*errdetails.BadRequest_FieldViolation, len(err.Validations()))
-		for i, ve := range err.Validations() {
-			ves[i] = &errdetails.BadRequest_FieldViolation{
-				Field:       ve.Field,
-				Description: ve.Message,
-			}
-		}
+// func getValidationErrors(e error) []*errdetails.BadRequest_FieldViolation {
+// 	if err, ok := e.(exception.CustomError); ok {
+// 		ves := make([]*errdetails.BadRequest_FieldViolation, len(err.Validations()))
+// 		for i, ve := range err.Validations() {
+// 			ves[i] = &errdetails.BadRequest_FieldViolation{
+// 				Field:       ve.Field,
+// 				Description: ve.Message,
+// 			}
+// 		}
 
-		return ves
-	}
+// 		return ves
+// 	}
 
-	return []*errdetails.BadRequest_FieldViolation{}
-}
+// 	return []*errdetails.BadRequest_FieldViolation{}
+// }

--- a/api/server/information/internal/interface/grpc/v1/error.go
+++ b/api/server/information/internal/interface/grpc/v1/error.go
@@ -1,4 +1,4 @@
-// package v1
+package v1
 
 // import (
 // 	"fmt"

--- a/api/server/user/internal/application/admin_test.go
+++ b/api/server/user/internal/application/admin_test.go
@@ -15,27 +15,29 @@ import (
 )
 
 func TestAdminApplication_List(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		input *input.ListAdmin
+	}
+	type want struct {
+		users  []*user.User
+		output *output.ListQuery
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Input    *input.ListAdmin
-		Expected struct {
-			Users  []*user.User
-			Output *output.ListQuery
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.ListAdmin{
-				Limit:  100,
-				Offset: 0,
+			args: args{
+				input: &input.ListAdmin{
+					Limit:  100,
+					Offset: 0,
+				},
 			},
-			Expected: struct {
-				Users  []*user.User
-				Output *output.ListQuery
-				Error  error
-			}{
-				Users: []*user.User{
+			want: want{
+				users: []*user.User{
 					{
 						ID:               "00000000-0000-0000-0000-000000000000",
 						Username:         "test-user",
@@ -59,18 +61,18 @@ func TestAdminApplication_List(t *testing.T) {
 						UpdatedAt:        current,
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 					Order:  nil,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -78,23 +80,23 @@ func TestAdminApplication_List(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().ListAdmin(tc.Input).Return(nil)
+		arvm.EXPECT().ListAdmin(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.Expected.Users, tc.Expected.Error)
-		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.Expected.Output.Total, tc.Expected.Error)
+		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.want.users, tc.want.err)
+		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.want.output.Total, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			users, _, err := target.List(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			users, _, err := target.List(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(users, tc.Expected.Users) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Users, users)
+			if !reflect.DeepEqual(users, tc.want.users) {
+				t.Fatalf("want %#v, but %#v", tc.want.users, users)
 				return
 			}
 		})
@@ -102,29 +104,32 @@ func TestAdminApplication_List(t *testing.T) {
 }
 
 func TestAdminApplication_Search(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		input *input.SearchAdmin
+	}
+	type want struct {
+		users  []*user.User
+		output *output.ListQuery
+		err    error
+	}
+
+	current := time.Now().Local()
 
 	testCases := map[string]struct {
-		Input    *input.SearchAdmin
-		Expected struct {
-			Users  []*user.User
-			Output *output.ListQuery
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.SearchAdmin{
-				Limit:  100,
-				Offset: 0,
-				Field:  "email",
-				Value:  "test-user@calmato.com",
+			args: args{
+				input: &input.SearchAdmin{
+					Limit:  100,
+					Offset: 0,
+					Field:  "email",
+					Value:  "test-user@calmato.com",
+				},
 			},
-			Expected: struct {
-				Users  []*user.User
-				Output *output.ListQuery
-				Error  error
-			}{
-				Users: []*user.User{
+			want: want{
+				users: []*user.User{
 					{
 						ID:               "00000000-0000-0000-0000-000000000000",
 						Username:         "test-user",
@@ -148,18 +153,18 @@ func TestAdminApplication_Search(t *testing.T) {
 						UpdatedAt:        current,
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 					Order:  nil,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -167,23 +172,23 @@ func TestAdminApplication_Search(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().SearchAdmin(tc.Input).Return(nil)
+		arvm.EXPECT().SearchAdmin(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.Expected.Users, tc.Expected.Error)
-		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.Expected.Output.Total, tc.Expected.Error)
+		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.want.users, tc.want.err)
+		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.want.output.Total, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			users, _, err := target.Search(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			users, _, err := target.Search(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(users, tc.Expected.Users) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Users, users)
+			if !reflect.DeepEqual(users, tc.want.users) {
+				t.Fatalf("want %#v, but %#v", tc.want.users, users)
 				return
 			}
 		})
@@ -191,22 +196,25 @@ func TestAdminApplication_Search(t *testing.T) {
 }
 
 func TestAdminApplication_Show(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		uid string
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
 
+	current := time.Now()
 	testCases := map[string]struct {
-		UID      string
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID: "00000000-0000-0000-0000-000000000000",
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			args: args{
+				uid: "00000000-0000-0000-0000-000000000000",
+			},
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -228,12 +236,12 @@ func TestAdminApplication_Show(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -243,19 +251,19 @@ func TestAdminApplication_Show(t *testing.T) {
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(tc.Expected.User, tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			got, err := target.Show(ctx, tc.UID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.Show(ctx, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -263,29 +271,33 @@ func TestAdminApplication_Show(t *testing.T) {
 }
 
 func TestAdminApplication_Create(t *testing.T) {
+	type args struct {
+		input *input.CreateAdmin
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.CreateAdmin
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.CreateAdmin{
-				Username:      "test-user",
-				Email:         "test@calmato.com",
-				Password:      "12345678",
-				Role:          1,
-				LastName:      "テスト",
-				FirstName:     "ユーザ",
-				LastNameKana:  "てすと",
-				FirstNameKana: "ゆーざ",
+			args: args{
+				input: &input.CreateAdmin{
+					Username:      "test-user",
+					Email:         "test@calmato.com",
+					Password:      "12345678",
+					Role:          1,
+					LastName:      "テスト",
+					FirstName:     "ユーザ",
+					LastNameKana:  "てすと",
+					FirstNameKana: "ゆーざ",
+				},
 			},
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					Username:      "test-user",
 					Email:         "test@calmato.com",
 					Password:      "12345678",
@@ -296,12 +308,12 @@ func TestAdminApplication_Create(t *testing.T) {
 					LastNameKana:  "てすと",
 					FirstNameKana: "ゆーざ",
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -309,23 +321,23 @@ func TestAdminApplication_Create(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().CreateAdmin(tc.Input).Return(nil)
+		arvm.EXPECT().CreateAdmin(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected.Error)
-		usm.EXPECT().Create(ctx, gomock.Any()).Return(tc.Expected.Error)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Create(ctx, gomock.Any()).Return(tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			got, err := target.Create(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.Create(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -333,35 +345,39 @@ func TestAdminApplication_Create(t *testing.T) {
 }
 
 func TestAdminApplication_UpdateContact(t *testing.T) {
+	type args struct {
+		uid   string
+		input *input.UpdateAdminContact
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAdminContact
-		ID       string
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.UpdateAdminContact{
-				Email:       "test-user@calmato.jp",
-				PhoneNumber: "000-0000-0000",
+			args: args{
+				uid: "12345678-1234-1234-1234-12345678901234",
+				input: &input.UpdateAdminContact{
+					Email:       "test-user@calmato.jp",
+					PhoneNumber: "000-0000-0000",
+				},
 			},
-			ID: "12345678-1234-1234-1234-12345678901234",
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					ID:          "12345678-1234-1234-1234-12345678901234",
 					Email:       "test-user@calmato.jp",
 					PhoneNumber: "000-0000-0000",
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -369,24 +385,24 @@ func TestAdminApplication_UpdateContact(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAdminContact(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAdminContact(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected.Error)
-		usm.EXPECT().Show(ctx, tc.ID).Return(tc.Expected.User, tc.Expected.Error)
-		usm.EXPECT().Update(ctx, tc.Expected.User).Return(tc.Expected.Error)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, nil)
+		usm.EXPECT().Update(ctx, tc.want.user).Return(tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			got, err := target.UpdateContact(ctx, tc.Input, tc.ID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.UpdateContact(ctx, tc.args.input, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -394,34 +410,38 @@ func TestAdminApplication_UpdateContact(t *testing.T) {
 }
 
 func TestAdminApplication_UpdatePassword(t *testing.T) {
+	type args struct {
+		uid   string
+		input *input.UpdateAdminPassword
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAdminPassword
-		ID       string
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.UpdateAdminPassword{
-				Password:             "12345678",
-				PasswordConfirmation: "12345678",
+			args: args{
+				uid: "12345678-1234-1234-1234-12345678901234",
+				input: &input.UpdateAdminPassword{
+					Password:             "12345678",
+					PasswordConfirmation: "12345678",
+				},
 			},
-			ID: "12345678-1234-1234-1234-12345678901234",
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					ID:       "12345678-1234-1234-1234-12345678901234",
 					Password: "12345678",
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -429,23 +449,23 @@ func TestAdminApplication_UpdatePassword(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAdminPassword(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAdminPassword(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.ID).Return(tc.Expected.User, tc.Expected.Error)
-		usm.EXPECT().UpdatePassword(ctx, tc.Expected.User.ID, tc.Expected.User.Password).Return(tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, nil)
+		usm.EXPECT().UpdatePassword(ctx, tc.want.user.ID, tc.want.user.Password).Return(tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			got, err := target.UpdatePassword(ctx, tc.Input, tc.ID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.UpdatePassword(ctx, tc.args.input, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -453,30 +473,34 @@ func TestAdminApplication_UpdatePassword(t *testing.T) {
 }
 
 func TestAdminApplication_UpdateProfile(t *testing.T) {
+	type args struct {
+		uid   string
+		input *input.UpdateAdminProfile
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAdminProfile
-		ID       string
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.UpdateAdminProfile{
-				Username:      "test-user",
-				LastName:      "テスト",
-				FirstName:     "ユーザ",
-				LastNameKana:  "てすと",
-				FirstNameKana: "ゆーざ",
-				Role:          1,
-				ThumbnailURL:  "https://www.google.co.jp",
+			args: args{
+				uid: "12345678-1234-1234-1234-12345678901234",
+				input: &input.UpdateAdminProfile{
+					Username:      "test-user",
+					LastName:      "テスト",
+					FirstName:     "ユーザ",
+					LastNameKana:  "てすと",
+					FirstNameKana: "ゆーざ",
+					Role:          1,
+					ThumbnailURL:  "https://www.google.co.jp",
+				},
 			},
-			ID: "12345678-1234-1234-1234-12345678901234",
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					ID:            "12345678-1234-1234-1234-12345678901234",
 					Username:      "test-user",
 					Email:         "test@calmato.com",
@@ -487,12 +511,12 @@ func TestAdminApplication_UpdateProfile(t *testing.T) {
 					Role:          1,
 					ThumbnailURL:  "https://www.google.co.jp",
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -500,24 +524,24 @@ func TestAdminApplication_UpdateProfile(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAdminProfile(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAdminProfile(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected.Error)
-		usm.EXPECT().Show(ctx, tc.ID).Return(tc.Expected.User, tc.Expected.Error)
-		usm.EXPECT().Update(ctx, tc.Expected.User).Return(tc.Expected.Error)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, nil)
+		usm.EXPECT().Update(ctx, tc.want.user).Return(tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			got, err := target.UpdateProfile(ctx, tc.Input, tc.ID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.UpdateProfile(ctx, tc.args.input, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -525,17 +549,23 @@ func TestAdminApplication_UpdateProfile(t *testing.T) {
 }
 
 func TestAdminApplication_Delete(t *testing.T) {
+	type args struct {
+		uid string
+	}
+
 	testCases := map[string]struct {
-		UID      string
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			UID:      "00000000-0000-0000-0000-000000000000",
-			Expected: nil,
+			args: args{
+				uid: "00000000-0000-0000-0000-000000000000",
+			},
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -543,21 +573,21 @@ func TestAdminApplication_Delete(t *testing.T) {
 		defer ctrl.Finish()
 
 		u := &user.User{
-			ID: tc.UID,
+			ID: tc.args.uid,
 		}
 
 		arvm := mock_validation.NewMockAdminRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(u, nil)
-		usm.EXPECT().Update(ctx, u).Return(tc.Expected)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(u, nil)
+		usm.EXPECT().Update(ctx, u).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminApplication(arvm, usm)
 
-			err := target.Delete(ctx, tc.UID)
-			if !reflect.DeepEqual(err, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, err)
+			err := target.Delete(ctx, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, err)
 				return
 			}
 		})

--- a/api/server/user/internal/application/auth_test.go
+++ b/api/server/user/internal/application/auth_test.go
@@ -14,20 +14,18 @@ import (
 )
 
 func TestAuthApplication_Authentication(t *testing.T) {
-	current := time.Now()
+	type want struct {
+		user *user.User
+		err  error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		want want
 	}{
 		"ok": {
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -49,12 +47,12 @@ func TestAuthApplication_Authentication(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -64,20 +62,20 @@ func TestAuthApplication_Authentication(t *testing.T) {
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Authentication(ctx).Return(tc.Expected.User.ID, tc.Expected.Error)
-		usm.EXPECT().Show(ctx, tc.Expected.User.ID).Return(tc.Expected.User, tc.Expected.Error)
+		usm.EXPECT().Authentication(ctx).Return(tc.want.user.ID, nil)
+		usm.EXPECT().Show(ctx, tc.want.user.ID).Return(tc.want.user, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got, err := target.Authentication(ctx)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.Authentication(ctx)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -85,37 +83,41 @@ func TestAuthApplication_Authentication(t *testing.T) {
 }
 
 func TestAuthApplication_Create(t *testing.T) {
+	type args struct {
+		input *input.CreateAuth
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.CreateAuth
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.CreateAuth{
-				Username:             "test-user",
-				Email:                "test-user@calmato.com",
-				Password:             "12345678",
-				PasswordConfirmation: "12345678",
+			args: args{
+				input: &input.CreateAuth{
+					Username:             "test-user",
+					Email:                "test-user@calmato.com",
+					Password:             "12345678",
+					PasswordConfirmation: "12345678",
+				},
 			},
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			want: want{
+				user: &user.User{
 					Username: "test-user",
 					Email:    "test-user@calmato.com",
 					Password: "12345678",
 					Gender:   0,
 					Role:     0,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -123,23 +125,23 @@ func TestAuthApplication_Create(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().CreateAuth(tc.Input).Return(nil)
+		arvm.EXPECT().CreateAuth(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected.Error)
-		usm.EXPECT().Create(ctx, gomock.Any()).Return(tc.Expected.Error)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Create(ctx, gomock.Any()).Return(tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got, err := target.Create(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.Create(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, got)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -147,21 +149,27 @@ func TestAuthApplication_Create(t *testing.T) {
 }
 
 func TestAuthApplication_UpdateEmail(t *testing.T) {
+	type args struct {
+		input *input.UpdateAuthEmail
+		user  *user.User
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAuthEmail
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Input: &input.UpdateAuthEmail{
-				Email: "test-user@calmato.com",
+			args: args{
+				input: &input.UpdateAuthEmail{
+					Email: "test-user@calmato.com",
+				},
+				user: &user.User{},
 			},
-			User:     &user.User{},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -169,18 +177,23 @@ func TestAuthApplication_UpdateEmail(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAuthEmail(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAuthEmail(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, tc.User).Return(tc.Expected)
-		usm.EXPECT().Update(ctx, tc.User).Return(tc.Expected)
+		usm.EXPECT().Validation(ctx, tc.args.user).Return(nil)
+		usm.EXPECT().Update(ctx, tc.args.user).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got := target.UpdateEmail(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.UpdateEmail(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
+				return
+			}
+
+			if tc.args.user.Email != tc.args.input.Email {
+				t.Fatalf("want %#v, but %#v", tc.args.input.Email, tc.args.user.Email)
 				return
 			}
 		})
@@ -188,24 +201,30 @@ func TestAuthApplication_UpdateEmail(t *testing.T) {
 }
 
 func TestAuthApplication_UpdatePassword(t *testing.T) {
+	type args struct {
+		input *input.UpdateAuthPassword
+		user  *user.User
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAuthPassword
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Input: &input.UpdateAuthPassword{
-				Password:             "12345678",
-				PasswordConfirmation: "12345678",
+			args: args{
+				input: &input.UpdateAuthPassword{
+					Password:             "12345678",
+					PasswordConfirmation: "12345678",
+				},
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
-			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -213,17 +232,17 @@ func TestAuthApplication_UpdatePassword(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAuthPassword(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAuthPassword(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().UpdatePassword(ctx, tc.User.ID, tc.Input.Password).Return(tc.Expected)
+		usm.EXPECT().UpdatePassword(ctx, tc.args.user.ID, tc.args.input.Password).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got := target.UpdatePassword(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.UpdatePassword(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
 				return
 			}
 		})
@@ -231,26 +250,32 @@ func TestAuthApplication_UpdatePassword(t *testing.T) {
 }
 
 func TestAuthApplication_UpdateProfile(t *testing.T) {
+	type args struct {
+		input *input.UpdateAuthProfile
+		user  *user.User
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAuthProfile
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Input: &input.UpdateAuthProfile{
-				Username:         "test-user",
-				Gender:           0,
-				ThumbnailURL:     "",
-				SelfIntroduction: "自己紹介",
+			args: args{
+				input: &input.UpdateAuthProfile{
+					Username:         "test-user",
+					Gender:           0,
+					ThumbnailURL:     "",
+					SelfIntroduction: "自己紹介",
+				},
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
-			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -258,18 +283,38 @@ func TestAuthApplication_UpdateProfile(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAuthProfile(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAuthProfile(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected)
-		usm.EXPECT().Update(ctx, tc.User).Return(tc.Expected)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Update(ctx, tc.args.user).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got := target.UpdateProfile(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.UpdateProfile(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
+				return
+			}
+
+			if tc.args.user.Username != tc.args.input.Username {
+				t.Fatalf("want %#v, but %#v", tc.args.input.Username, tc.args.user.Username)
+				return
+			}
+
+			if tc.args.user.Gender != tc.args.input.Gender {
+				t.Fatalf("want %#v, but %#v", tc.args.input.Gender, tc.args.user.Gender)
+				return
+			}
+
+			if tc.args.user.ThumbnailURL != tc.args.input.ThumbnailURL {
+				t.Fatalf("want %#v, but %#v", tc.args.input.ThumbnailURL, tc.args.user.ThumbnailURL)
+				return
+			}
+
+			if tc.args.user.SelfIntroduction != tc.args.input.SelfIntroduction {
+				t.Fatalf("want %#v, but %#v", tc.args.input.SelfIntroduction, tc.args.user.SelfIntroduction)
 				return
 			}
 		})
@@ -277,32 +322,38 @@ func TestAuthApplication_UpdateProfile(t *testing.T) {
 }
 
 func TestAuthApplication_UpdateAddress(t *testing.T) {
+	type args struct {
+		input *input.UpdateAuthAddress
+		user  *user.User
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UpdateAuthAddress
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Input: &input.UpdateAuthAddress{
-				LastName:      "テスト",
-				FirstName:     "ユーザ",
-				LastNameKana:  "てすと",
-				FirstNameKana: "ゆーざ",
-				PhoneNumber:   "000-0000-0000",
-				PostalCode:    "000-0000",
-				Prefecture:    "東京都",
-				City:          "小金井市",
-				AddressLine1:  "貫井北町4-1-1",
-				AddressLine2:  "",
+			args: args{
+				input: &input.UpdateAuthAddress{
+					LastName:      "テスト",
+					FirstName:     "ユーザ",
+					LastNameKana:  "てすと",
+					FirstNameKana: "ゆーざ",
+					PhoneNumber:   "000-0000-0000",
+					PostalCode:    "000-0000",
+					Prefecture:    "東京都",
+					City:          "小金井市",
+					AddressLine1:  "貫井北町4-1-1",
+					AddressLine2:  "自然科学棟 N110",
+				},
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
-			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -310,18 +361,68 @@ func TestAuthApplication_UpdateAddress(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().UpdateAuthAddress(tc.Input).Return(nil)
+		arvm.EXPECT().UpdateAuthAddress(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Validation(ctx, gomock.Any()).Return(tc.Expected)
-		usm.EXPECT().Update(ctx, tc.User).Return(tc.Expected)
+		usm.EXPECT().Validation(ctx, gomock.Any()).Return(nil)
+		usm.EXPECT().Update(ctx, tc.args.user).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got := target.UpdateAddress(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.UpdateAddress(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
+				return
+			}
+
+			if tc.args.user.LastName != tc.args.input.LastName {
+				t.Fatalf("want %#v, but %#v", tc.args.input.LastName, tc.args.user.LastName)
+				return
+			}
+
+			if tc.args.user.FirstName != tc.args.input.FirstName {
+				t.Fatalf("want %#v, but %#v", tc.args.input.FirstName, tc.args.user.FirstName)
+				return
+			}
+
+			if tc.args.user.LastNameKana != tc.args.input.LastNameKana {
+				t.Fatalf("want %#v, but %#v", tc.args.input.LastNameKana, tc.args.user.LastNameKana)
+				return
+			}
+
+			if tc.args.user.FirstNameKana != tc.args.input.FirstNameKana {
+				t.Fatalf("want %#v, but %#v", tc.args.input.FirstNameKana, tc.args.user.FirstNameKana)
+				return
+			}
+
+			if tc.args.user.PhoneNumber != tc.args.input.PhoneNumber {
+				t.Fatalf("want %#v, but %#v", tc.args.input.PhoneNumber, tc.args.user.PhoneNumber)
+				return
+			}
+
+			if tc.args.user.PostalCode != tc.args.input.PostalCode {
+				t.Fatalf("want %#v, but %#v", tc.args.input.PostalCode, tc.args.user.PostalCode)
+				return
+			}
+
+			if tc.args.user.Prefecture != tc.args.input.Prefecture {
+				t.Fatalf("want %#v, but %#v", tc.args.input.Prefecture, tc.args.user.Prefecture)
+				return
+			}
+
+			if tc.args.user.City != tc.args.input.City {
+				t.Fatalf("want %#v, but %#v", tc.args.input.City, tc.args.user.City)
+				return
+			}
+
+			if tc.args.user.AddressLine1 != tc.args.input.AddressLine1 {
+				t.Fatalf("want %#v, but %#v", tc.args.input.AddressLine1, tc.args.user.AddressLine1)
+				return
+			}
+
+			if tc.args.user.AddressLine2 != tc.args.input.AddressLine2 {
+				t.Fatalf("want %#v, but %#v", tc.args.input.AddressLine2, tc.args.user.AddressLine2)
 				return
 			}
 		})
@@ -329,32 +430,36 @@ func TestAuthApplication_UpdateAddress(t *testing.T) {
 }
 
 func TestAuthApplication_UploadThumbnail(t *testing.T) {
+	type args struct {
+		input *input.UploadAuthThumbnail
+		user  *user.User
+	}
+	type want struct {
+		thumbnailURL string
+		err          error
+	}
+
 	testCases := map[string]struct {
-		Input    *input.UploadAuthThumbnail
-		User     *user.User
-		Expected struct {
-			ThumbnailURL string
-			Error        error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.UploadAuthThumbnail{
-				Thumbnail: []byte("あいうえお"),
+			args: args{
+				input: &input.UploadAuthThumbnail{
+					Thumbnail: []byte("あいうえお"),
+				},
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
-			},
-			Expected: struct {
-				ThumbnailURL string
-				Error        error
-			}{
-				ThumbnailURL: "https://google.co.jp",
-				Error:        nil,
+			want: want{
+				thumbnailURL: "https://google.co.jp",
+				err:          nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -362,24 +467,24 @@ func TestAuthApplication_UploadThumbnail(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().UploadAuthThumbnail(tc.Input).Return(nil)
+		arvm.EXPECT().UploadAuthThumbnail(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
 		usm.EXPECT().
-			UploadThumbnail(ctx, tc.User.ID, tc.Input.Thumbnail).
-			Return(tc.Expected.ThumbnailURL, tc.Expected.Error)
+			UploadThumbnail(ctx, tc.args.user.ID, tc.args.input.Thumbnail).
+			Return(tc.want.thumbnailURL, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			got, err := target.UploadThumbnail(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			thumbnailURL, err := target.UploadThumbnail(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(got, tc.Expected.ThumbnailURL) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.ThumbnailURL, got)
+			if !reflect.DeepEqual(thumbnailURL, tc.want.thumbnailURL) {
+				t.Fatalf("want %#v, but %#v", tc.want.thumbnailURL, thumbnailURL)
 				return
 			}
 		})
@@ -387,19 +492,25 @@ func TestAuthApplication_UploadThumbnail(t *testing.T) {
 }
 
 func TestAuthApplication_Delete(t *testing.T) {
+	type args struct {
+		user *user.User
+	}
+
 	testCases := map[string]struct {
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
+			args: args{
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -409,14 +520,14 @@ func TestAuthApplication_Delete(t *testing.T) {
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Delete(ctx, tc.User.ID).Return(tc.Expected)
+		usm.EXPECT().Delete(ctx, tc.args.user.ID).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			err := target.Delete(ctx, tc.User)
-			if !reflect.DeepEqual(err, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, err)
+			err := target.Delete(ctx, tc.args.user)
+			if !reflect.DeepEqual(err, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, err)
 				return
 			}
 		})
@@ -424,23 +535,29 @@ func TestAuthApplication_Delete(t *testing.T) {
 }
 
 func TestAuthApplication_RegisterDevice(t *testing.T) {
+	type args struct {
+		input *input.RegisterAuthDevice
+		user  *user.User
+	}
+
 	testCases := map[string]struct {
-		Input    *input.RegisterAuthDevice
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Input: &input.RegisterAuthDevice{
-				InstanceID: "cTP0f6Y_Q26VG9TbTjReZz:APA91bG6Ns9A5DsXaMcImyyNImS4VD",
+			args: args{
+				input: &input.RegisterAuthDevice{
+					InstanceID: "cTP0f6Y_Q26VG9TbTjReZz:APA91bG6Ns9A5DsXaMcImyyNImS4VD",
+				},
+				user: &user.User{
+					ID: "00000000-0000-0000-0000-000000000000",
+				},
 			},
-			User: &user.User{
-				ID: "00000000-0000-0000-0000-000000000000",
-			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -448,17 +565,22 @@ func TestAuthApplication_RegisterDevice(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockAuthRequestValidation(ctrl)
-		arvm.EXPECT().RegisterAuthDevice(tc.Input).Return(nil)
+		arvm.EXPECT().RegisterAuthDevice(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Update(ctx, tc.User).Return(tc.Expected)
+		usm.EXPECT().Update(ctx, tc.args.user).Return(tc.want)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthApplication(arvm, usm)
 
-			err := target.RegisterDevice(ctx, tc.Input, tc.User)
-			if !reflect.DeepEqual(err, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, err)
+			err := target.RegisterDevice(ctx, tc.args.input, tc.args.user)
+			if !reflect.DeepEqual(err, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, err)
+				return
+			}
+
+			if tc.args.user.InstanceID != tc.args.input.InstanceID {
+				t.Fatalf("want %#v, but %#v", tc.args.input.InstanceID, tc.args.user.InstanceID)
 				return
 			}
 		})

--- a/api/server/user/internal/application/user_test.go
+++ b/api/server/user/internal/application/user_test.go
@@ -15,27 +15,29 @@ import (
 )
 
 func TestUserApplication_List(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		input *input.ListUser
+	}
+	type want struct {
+		users  []*user.User
+		output *output.ListQuery
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Input    *input.ListUser
-		Expected struct {
-			Users  []*user.User
-			Output *output.ListQuery
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.ListUser{
-				Limit:  100,
-				Offset: 0,
+			args: args{
+				input: &input.ListUser{
+					Limit:  100,
+					Offset: 0,
+				},
 			},
-			Expected: struct {
-				Users  []*user.User
-				Output *output.ListQuery
-				Error  error
-			}{
-				Users: []*user.User{
+			want: want{
+				users: []*user.User{
 					{
 						ID:               "00000000-0000-0000-0000-000000000000",
 						Username:         "test-user",
@@ -59,18 +61,18 @@ func TestUserApplication_List(t *testing.T) {
 						UpdatedAt:        current,
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 					Order:  nil,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -78,23 +80,23 @@ func TestUserApplication_List(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockUserRequestValidation(ctrl)
-		arvm.EXPECT().ListUser(tc.Input).Return(nil)
+		arvm.EXPECT().ListUser(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.Expected.Users, tc.Expected.Error)
-		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.Expected.Output.Total, tc.Expected.Error)
+		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.want.users, nil)
+		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.want.output.Total, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(arvm, usm)
 
-			users, _, err := target.List(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			users, _, err := target.List(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(users, tc.Expected.Users) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Users, users)
+			if !reflect.DeepEqual(users, tc.want.users) {
+				t.Fatalf("want %#v, but %#v", tc.want.users, users)
 				return
 			}
 		})
@@ -102,26 +104,29 @@ func TestUserApplication_List(t *testing.T) {
 }
 
 func TestUserApplication_ListUserByIDs(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		input *input.ListUserByUserIDs
+	}
+	type want struct {
+		users []*user.User
+		err   error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Input    *input.ListUserByUserIDs
-		Expected struct {
-			Users []*user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.ListUserByUserIDs{
-				UserIDs: []string{
-					"00000000-0000-0000-0000-000000000000",
+			args: args{
+				input: &input.ListUserByUserIDs{
+					UserIDs: []string{
+						"00000000-0000-0000-0000-000000000000",
+					},
 				},
 			},
-			Expected: struct {
-				Users []*user.User
-				Error error
-			}{
-				Users: []*user.User{
+			want: want{
+				users: []*user.User{
 					{
 						ID:               "00000000-0000-0000-0000-000000000000",
 						Username:         "test-user",
@@ -145,12 +150,12 @@ func TestUserApplication_ListUserByIDs(t *testing.T) {
 						UpdatedAt:        current,
 					},
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -158,22 +163,22 @@ func TestUserApplication_ListUserByIDs(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockUserRequestValidation(ctrl)
-		arvm.EXPECT().ListUserByUserIDs(tc.Input).Return(nil)
+		arvm.EXPECT().ListUserByUserIDs(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.Expected.Users, tc.Expected.Error)
+		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.want.users, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(arvm, usm)
 
-			users, err := target.ListByUserIDs(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			users, err := target.ListByUserIDs(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(users, tc.Expected.Users) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Users, users)
+			if !reflect.DeepEqual(users, tc.want.users) {
+				t.Fatalf("want %#v, but %#v", tc.want.users, users)
 				return
 			}
 		})
@@ -181,29 +186,32 @@ func TestUserApplication_ListUserByIDs(t *testing.T) {
 }
 
 func TestUserApplication_ListFollow(t *testing.T) {
+	type args struct {
+		uid   string
+		cuid  string
+		input *input.ListFollow
+	}
+	type want struct {
+		follows []*user.Follow
+		output  *output.ListQuery
+		err     error
+	}
+
 	testCases := map[string]struct {
-		UID      string
-		CUID     string
-		Input    *input.ListFollow
-		Expected struct {
-			Follows []*user.Follow
-			Output  *output.ListQuery
-			Error   error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID:  "00000000-0000-0000-0000-000000000000",
-			CUID: "11111111-1111-1111-1111-111111111111",
-			Input: &input.ListFollow{
-				Limit:  100,
-				Offset: 0,
+			args: args{
+				uid:  "00000000-0000-0000-0000-000000000000",
+				cuid: "11111111-1111-1111-1111-111111111111",
+				input: &input.ListFollow{
+					Limit:  100,
+					Offset: 0,
+				},
 			},
-			Expected: struct {
-				Follows []*user.Follow
-				Output  *output.ListQuery
-				Error   error
-			}{
-				Follows: []*user.Follow{
+			want: want{
+				follows: []*user.Follow{
 					{
 						FollowID:         "00000000-0000-0000-0000-000000000000",
 						FollowerID:       "11111111-1111-1111-1111-111111111111",
@@ -212,17 +220,17 @@ func TestUserApplication_ListFollow(t *testing.T) {
 						SelfIntroduction: "",
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -232,35 +240,33 @@ func TestUserApplication_ListFollow(t *testing.T) {
 		var followCount int
 		var followerCount int
 
-		if tc.Expected.Output != nil {
-			followCount = tc.Expected.Output.Total
+		if tc.want.output != nil {
+			followCount = tc.want.output.Total
 		}
 
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
-		urvm.EXPECT().ListFollow(tc.Input).Return(nil)
+		urvm.EXPECT().ListFollow(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().ListFollow(ctx, gomock.Any(), tc.CUID).Return(tc.Expected.Follows, tc.Expected.Error)
-		usm.EXPECT().
-			ListFriendCount(ctx, tc.UID).
-			Return(followCount, followerCount, tc.Expected.Error)
+		usm.EXPECT().ListFollow(ctx, gomock.Any(), tc.args.cuid).Return(tc.want.follows, tc.want.err)
+		usm.EXPECT().ListFriendCount(ctx, tc.args.uid).Return(followCount, followerCount, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			follows, output, err := target.ListFollow(ctx, tc.Input, tc.UID, tc.CUID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			follows, output, err := target.ListFollow(ctx, tc.args.input, tc.args.uid, tc.args.cuid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(follows, tc.Expected.Follows) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Follows, follows)
+			if !reflect.DeepEqual(follows, tc.want.follows) {
+				t.Fatalf("want %#v, but %#v", tc.want.follows, follows)
 				return
 			}
 
-			if !reflect.DeepEqual(output, tc.Expected.Output) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Output, output)
+			if !reflect.DeepEqual(output, tc.want.output) {
+				t.Fatalf("want %#v, but %#v", tc.want.output, output)
 				return
 			}
 		})
@@ -268,29 +274,32 @@ func TestUserApplication_ListFollow(t *testing.T) {
 }
 
 func TestUserApplication_ListFollower(t *testing.T) {
+	type args struct {
+		uid   string
+		cuid  string
+		input *input.ListFollower
+	}
+	type want struct {
+		followers []*user.Follower
+		output    *output.ListQuery
+		err       error
+	}
+
 	testCases := map[string]struct {
-		UID      string
-		CUID     string
-		Input    *input.ListFollower
-		Expected struct {
-			Followers []*user.Follower
-			Output    *output.ListQuery
-			Error     error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID:  "00000000-0000-0000-0000-000000000000",
-			CUID: "11111111-1111-1111-1111-111111111111",
-			Input: &input.ListFollower{
-				Limit:  100,
-				Offset: 0,
+			args: args{
+				uid:  "00000000-0000-0000-0000-000000000000",
+				cuid: "11111111-1111-1111-1111-111111111111",
+				input: &input.ListFollower{
+					Limit:  100,
+					Offset: 0,
+				},
 			},
-			Expected: struct {
-				Followers []*user.Follower
-				Output    *output.ListQuery
-				Error     error
-			}{
-				Followers: []*user.Follower{
+			want: want{
+				followers: []*user.Follower{
 					{
 						FollowID:         "11111111-1111-1111-1111-111111111111",
 						FollowerID:       "00000000-0000-0000-0000-000000000000",
@@ -299,17 +308,17 @@ func TestUserApplication_ListFollower(t *testing.T) {
 						SelfIntroduction: "",
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -319,35 +328,33 @@ func TestUserApplication_ListFollower(t *testing.T) {
 		var followCount int
 		var followerCount int
 
-		if tc.Expected.Output != nil {
-			followerCount = tc.Expected.Output.Total
+		if tc.want.output != nil {
+			followerCount = tc.want.output.Total
 		}
 
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
-		urvm.EXPECT().ListFollower(tc.Input).Return(nil)
+		urvm.EXPECT().ListFollower(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().ListFollower(ctx, gomock.Any(), tc.CUID).Return(tc.Expected.Followers, tc.Expected.Error)
-		usm.EXPECT().
-			ListFriendCount(ctx, tc.UID).
-			Return(followCount, followerCount, tc.Expected.Error)
+		usm.EXPECT().ListFollower(ctx, gomock.Any(), tc.args.cuid).Return(tc.want.followers, tc.want.err)
+		usm.EXPECT().ListFriendCount(ctx, tc.args.uid).Return(followCount, followerCount, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			followers, output, err := target.ListFollower(ctx, tc.Input, tc.UID, tc.CUID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			followers, output, err := target.ListFollower(ctx, tc.args.input, tc.args.uid, tc.args.cuid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(followers, tc.Expected.Followers) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Followers, followers)
+			if !reflect.DeepEqual(followers, tc.want.followers) {
+				t.Fatalf("want %#v, but %#v", tc.want.followers, followers)
 				return
 			}
 
-			if !reflect.DeepEqual(output, tc.Expected.Output) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Output, output)
+			if !reflect.DeepEqual(output, tc.want.output) {
+				t.Fatalf("want %#v, but %#v", tc.want.output, output)
 				return
 			}
 		})
@@ -355,29 +362,31 @@ func TestUserApplication_ListFollower(t *testing.T) {
 }
 
 func TestUserApplication_Search(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		input *input.SearchUser
+	}
+	type want struct {
+		users  []*user.User
+		output *output.ListQuery
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Input    *input.SearchUser
-		Expected struct {
-			Users  []*user.User
-			Output *output.ListQuery
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			Input: &input.SearchUser{
-				Limit:  100,
-				Offset: 0,
-				Field:  "email",
-				Value:  "test-user@calmato.com",
+			args: args{
+				input: &input.SearchUser{
+					Limit:  100,
+					Offset: 0,
+					Field:  "email",
+					Value:  "test-user@calmato.com",
+				},
 			},
-			Expected: struct {
-				Users  []*user.User
-				Output *output.ListQuery
-				Error  error
-			}{
-				Users: []*user.User{
+			want: want{
+				users: []*user.User{
 					{
 						ID:               "00000000-0000-0000-0000-000000000000",
 						Username:         "test-user",
@@ -401,18 +410,18 @@ func TestUserApplication_Search(t *testing.T) {
 						UpdatedAt:        current,
 					},
 				},
-				Output: &output.ListQuery{
+				output: &output.ListQuery{
 					Limit:  100,
 					Offset: 0,
 					Total:  1,
 					Order:  nil,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -420,23 +429,23 @@ func TestUserApplication_Search(t *testing.T) {
 		defer ctrl.Finish()
 
 		arvm := mock_validation.NewMockUserRequestValidation(ctrl)
-		arvm.EXPECT().SearchUser(tc.Input).Return(nil)
+		arvm.EXPECT().SearchUser(tc.args.input).Return(nil)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.Expected.Users, tc.Expected.Error)
-		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.Expected.Output.Total, tc.Expected.Error)
+		usm.EXPECT().List(ctx, gomock.Any()).Return(tc.want.users, tc.want.err)
+		usm.EXPECT().ListCount(ctx, gomock.Any()).Return(tc.want.output.Total, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(arvm, usm)
 
-			users, _, err := target.Search(ctx, tc.Input)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			users, _, err := target.Search(ctx, tc.args.input)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(users, tc.Expected.Users) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Users, users)
+			if !reflect.DeepEqual(users, tc.want.users) {
+				t.Fatalf("want %#v, but %#v", tc.want.users, users)
 				return
 			}
 		})
@@ -444,22 +453,25 @@ func TestUserApplication_Search(t *testing.T) {
 }
 
 func TestUserApplication_Show(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		uid string
+	}
+	type want struct {
+		user *user.User
+		err  error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		UID      string
-		Expected struct {
-			User  *user.User
-			Error error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID: "00000000-0000-0000-0000-000000000000",
-			Expected: struct {
-				User  *user.User
-				Error error
-			}{
-				User: &user.User{
+			args: args{
+				uid: "00000000-0000-0000-0000-000000000000",
+			},
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -481,12 +493,12 @@ func TestUserApplication_Show(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -496,19 +508,19 @@ func TestUserApplication_Show(t *testing.T) {
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(tc.Expected.User, tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, tc.want.err)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			user, err := target.Show(ctx, tc.UID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, err := target.Show(ctx, tc.args.uid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(user, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, user)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 		})
@@ -516,26 +528,28 @@ func TestUserApplication_Show(t *testing.T) {
 }
 
 func TestUserApplication_GetUserProfile(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		uid  string
+		cuid string
+	}
+	type want struct {
+		user   *user.User
+		output *output.UserProfile
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		UID      string
-		CUID     string
-		Expected struct {
-			User   *user.User
-			Output *output.UserProfile
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID:  "00000000-0000-0000-0000-000000000000",
-			CUID: "11111111-1111-1111-1111-111111111111",
-			Expected: struct {
-				User   *user.User
-				Output *output.UserProfile
-				Error  error
-			}{
-				User: &user.User{
+			args: args{
+				uid:  "00000000-0000-0000-0000-000000000000",
+				cuid: "11111111-1111-1111-1111-111111111111",
+			},
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -557,18 +571,18 @@ func TestUserApplication_GetUserProfile(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Output: &output.UserProfile{
+				output: &output.UserProfile{
 					IsFollow:      true,
 					IsFollower:    false,
 					FollowCount:   1,
 					FollowerCount: 3,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -578,30 +592,30 @@ func TestUserApplication_GetUserProfile(t *testing.T) {
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(tc.Expected.User, tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, nil)
 		usm.EXPECT().
-			ListFriendCount(ctx, tc.UID).
-			Return(tc.Expected.Output.FollowCount, tc.Expected.Output.FollowerCount, tc.Expected.Error)
+			ListFriendCount(ctx, tc.args.uid).
+			Return(tc.want.output.FollowCount, tc.want.output.FollowerCount, tc.want.err)
 		usm.EXPECT().
-			IsFriend(ctx, tc.UID, tc.CUID).
-			Return(tc.Expected.Output.IsFollow, tc.Expected.Output.IsFollower)
+			IsFriend(ctx, tc.args.uid, tc.args.cuid).
+			Return(tc.want.output.IsFollow, tc.want.output.IsFollower)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			user, output, err := target.GetUserProfile(ctx, tc.UID, tc.CUID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, output, err := target.GetUserProfile(ctx, tc.args.uid, tc.args.cuid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(user, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, user)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 
-			if !reflect.DeepEqual(output, tc.Expected.Output) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Output, output)
+			if !reflect.DeepEqual(output, tc.want.output) {
+				t.Fatalf("want %#v, but %#v", tc.want.output, output)
 				return
 			}
 		})
@@ -609,26 +623,28 @@ func TestUserApplication_GetUserProfile(t *testing.T) {
 }
 
 func TestUserApplication_RegisterFollow(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		uid  string
+		cuid string
+	}
+	type want struct {
+		user   *user.User
+		output *output.UserProfile
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		UID      string
-		CUID     string
-		Expected struct {
-			User   *user.User
-			Output *output.UserProfile
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID:  "00000000-0000-0000-0000-000000000000",
-			CUID: "11111111-1111-1111-1111-111111111111",
-			Expected: struct {
-				User   *user.User
-				Output *output.UserProfile
-				Error  error
-			}{
-				User: &user.User{
+			args: args{
+				uid:  "00000000-0000-0000-0000-000000000000",
+				cuid: "11111111-1111-1111-1111-111111111111",
+			},
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -650,18 +666,18 @@ func TestUserApplication_RegisterFollow(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Output: &output.UserProfile{
+				output: &output.UserProfile{
 					IsFollow:      true,
 					IsFollower:    false,
 					FollowCount:   1,
 					FollowerCount: 3,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -669,39 +685,39 @@ func TestUserApplication_RegisterFollow(t *testing.T) {
 		defer ctrl.Finish()
 
 		r := &user.Relationship{
-			FollowID:   tc.CUID,
-			FollowerID: tc.UID,
+			FollowID:   tc.args.cuid,
+			FollowerID: tc.args.uid,
 		}
 
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(tc.Expected.User, tc.Expected.Error)
-		usm.EXPECT().ValidationRelationship(ctx, r).Return(tc.Expected.Error)
-		usm.EXPECT().CreateRelationship(ctx, r).Return(tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, nil)
+		usm.EXPECT().ValidationRelationship(ctx, r).Return(nil)
+		usm.EXPECT().CreateRelationship(ctx, r).Return(tc.want.err)
 		usm.EXPECT().
-			ListFriendCount(ctx, tc.UID).
-			Return(tc.Expected.Output.FollowCount, tc.Expected.Output.FollowerCount, tc.Expected.Error)
+			ListFriendCount(ctx, tc.args.uid).
+			Return(tc.want.output.FollowCount, tc.want.output.FollowerCount, nil)
 		usm.EXPECT().
-			IsFriend(ctx, tc.UID, tc.CUID).
-			Return(tc.Expected.Output.IsFollow, tc.Expected.Output.IsFollower)
+			IsFriend(ctx, tc.args.uid, tc.args.cuid).
+			Return(tc.want.output.IsFollow, tc.want.output.IsFollower)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			user, output, err := target.RegisterFollow(ctx, tc.UID, tc.CUID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, output, err := target.RegisterFollow(ctx, tc.args.uid, tc.args.cuid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(user, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, user)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 
-			if !reflect.DeepEqual(output, tc.Expected.Output) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Output, output)
+			if !reflect.DeepEqual(output, tc.want.output) {
+				t.Fatalf("want %#v, but %#v", tc.want.output, output)
 				return
 			}
 		})
@@ -709,26 +725,28 @@ func TestUserApplication_RegisterFollow(t *testing.T) {
 }
 
 func TestUserApplication_UnregisterFollow(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		uid  string
+		cuid string
+	}
+	type want struct {
+		user   *user.User
+		output *output.UserProfile
+		err    error
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		UID      string
-		CUID     string
-		Expected struct {
-			User   *user.User
-			Output *output.UserProfile
-			Error  error
-		}
+		args args
+		want want
 	}{
 		"ok": {
-			UID:  "00000000-0000-0000-0000-000000000000",
-			CUID: "11111111-1111-1111-1111-111111111111",
-			Expected: struct {
-				User   *user.User
-				Output *output.UserProfile
-				Error  error
-			}{
-				User: &user.User{
+			args: args{
+				uid:  "00000000-0000-0000-0000-000000000000",
+				cuid: "11111111-1111-1111-1111-111111111111",
+			},
+			want: want{
+				user: &user.User{
 					ID:               "00000000-0000-0000-0000-000000000000",
 					Username:         "test-user",
 					Gender:           0,
@@ -750,18 +768,18 @@ func TestUserApplication_UnregisterFollow(t *testing.T) {
 					CreatedAt:        current,
 					UpdatedAt:        current,
 				},
-				Output: &output.UserProfile{
+				output: &output.UserProfile{
 					IsFollow:      true,
 					IsFollower:    false,
 					FollowCount:   1,
 					FollowerCount: 3,
 				},
-				Error: nil,
+				err: nil,
 			},
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -770,39 +788,39 @@ func TestUserApplication_UnregisterFollow(t *testing.T) {
 
 		r := &user.Relationship{
 			ID:         1,
-			FollowID:   tc.CUID,
-			FollowerID: tc.UID,
+			FollowID:   tc.args.cuid,
+			FollowerID: tc.args.uid,
 		}
 
 		urvm := mock_validation.NewMockUserRequestValidation(ctrl)
 
 		usm := mock_user.NewMockService(ctrl)
-		usm.EXPECT().Show(ctx, tc.UID).Return(tc.Expected.User, tc.Expected.Error)
-		usm.EXPECT().ShowRelationshipByUID(ctx, tc.UID, tc.CUID).Return(r, tc.Expected.Error)
-		usm.EXPECT().DeleteRelationship(ctx, r.ID).Return(tc.Expected.Error)
+		usm.EXPECT().Show(ctx, tc.args.uid).Return(tc.want.user, tc.want.err)
+		usm.EXPECT().ShowRelationshipByUID(ctx, tc.args.uid, tc.args.cuid).Return(r, tc.want.err)
+		usm.EXPECT().DeleteRelationship(ctx, r.ID).Return(tc.want.err)
 		usm.EXPECT().
-			ListFriendCount(ctx, tc.UID).
-			Return(tc.Expected.Output.FollowCount, tc.Expected.Output.FollowerCount, tc.Expected.Error)
+			ListFriendCount(ctx, tc.args.uid).
+			Return(tc.want.output.FollowCount, tc.want.output.FollowerCount, tc.want.err)
 		usm.EXPECT().
-			IsFriend(ctx, tc.UID, tc.CUID).
-			Return(tc.Expected.Output.IsFollow, tc.Expected.Output.IsFollower)
+			IsFriend(ctx, tc.args.uid, tc.args.cuid).
+			Return(tc.want.output.IsFollow, tc.want.output.IsFollower)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserApplication(urvm, usm)
 
-			user, output, err := target.UnregisterFollow(ctx, tc.UID, tc.CUID)
-			if !reflect.DeepEqual(err, tc.Expected.Error) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Error, err)
+			user, output, err := target.UnregisterFollow(ctx, tc.args.uid, tc.args.cuid)
+			if !reflect.DeepEqual(err, tc.want.err) {
+				t.Fatalf("want %#v, but %#v", tc.want.err, err)
 				return
 			}
 
-			if !reflect.DeepEqual(user, tc.Expected.User) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.User, user)
+			if !reflect.DeepEqual(user, tc.want.user) {
+				t.Fatalf("want %#v, but %#v", tc.want.user, user)
 				return
 			}
 
-			if !reflect.DeepEqual(output, tc.Expected.Output) {
-				t.Fatalf("want %#v, but %#v", tc.Expected.Output, output)
+			if !reflect.DeepEqual(output, tc.want.output) {
+				t.Fatalf("want %#v, but %#v", tc.want.output, output)
 				return
 			}
 		})

--- a/api/server/user/internal/application/validation/admin_test.go
+++ b/api/server/user/internal/application/validation/admin_test.go
@@ -69,11 +69,11 @@ func TestAdminRequestValidation_ListAdmin(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.ListAdmin(tc.Input)
@@ -185,11 +185,11 @@ func TestAdminRequestValidation_SearchAdmin(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.SearchAdmin(tc.Input)
@@ -549,11 +549,11 @@ func TestAdminRequestValidation_CreateAdmin(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.CreateAdmin(tc.Input)
@@ -612,11 +612,11 @@ func TestAdminRequestValidation_UpdateAdminContact(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.UpdateAdminContact(tc.Input)
@@ -689,11 +689,11 @@ func TestAdminRequestValidation_UpdateAdminPassword(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.UpdateAdminPassword(tc.Input)
@@ -897,11 +897,11 @@ func TestAdminRequestValidation_UpdateAdminProfile(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.UpdateAdminProfile(tc.Input)
@@ -937,11 +937,11 @@ func TestAdminRequestValidation_UploadAdminThumbnail(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAdminRequestValidation()
 
 			got := target.UploadAdminThumbnail(tc.Input)

--- a/api/server/user/internal/application/validation/auth_test.go
+++ b/api/server/user/internal/application/validation/auth_test.go
@@ -123,11 +123,11 @@ func TestAuthRequestValidation_CreateAuth(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.CreateAuth(tc.Input)
@@ -175,11 +175,11 @@ func TestAuthRequestValidation_UpdateAuthEmail(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.UpdateAuthEmail(tc.Input)
@@ -252,11 +252,11 @@ func TestAuthRequestValidation_UpdateAuthPassword(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.UpdateAuthPassword(tc.Input)
@@ -334,11 +334,11 @@ func TestAuthRequestValidation_UpdateAuthProfile(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.UpdateAuthProfile(tc.Input)
@@ -688,11 +688,11 @@ func TestAuthRequestValidation_UpdateAuthAddress(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.UpdateAuthAddress(tc.Input)
@@ -728,11 +728,11 @@ func TestAuthRequestValidation_UploadAuthThumbnail(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.UploadAuthThumbnail(tc.Input)
@@ -768,11 +768,11 @@ func TestAuthRequestValidation_RegisterDevice(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewAuthRequestValidation()
 
 			got := target.RegisterAuthDevice(tc.Input)

--- a/api/server/user/internal/application/validation/chat_test.go
+++ b/api/server/user/internal/application/validation/chat_test.go
@@ -51,11 +51,11 @@ func TestChatRequestValidation_CreateRoom(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewChatRequestValidation()
 
 			got := target.CreateRoom(tc.Input)

--- a/api/server/user/internal/application/validation/user_test.go
+++ b/api/server/user/internal/application/validation/user_test.go
@@ -69,11 +69,11 @@ func TestUserRequestValidation_ListUser(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserRequestValidation()
 
 			got := target.ListUser(tc.Input)
@@ -133,11 +133,11 @@ func TestUserRequestValidation_ListUserByUserIDs(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserRequestValidation()
 
 			got := target.ListUserByUserIDs(tc.Input)
@@ -215,11 +215,11 @@ func TestUserRequestValidation_ListFollow(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserRequestValidation()
 
 			got := target.ListFollow(tc.Input)
@@ -297,11 +297,11 @@ func TestUserRequestValidation_ListFollower(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserRequestValidation()
 
 			got := target.ListFollower(tc.Input)
@@ -413,11 +413,11 @@ func TestUserRequestValidation_SearchUser(t *testing.T) {
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserRequestValidation()
 
 			got := target.SearchUser(tc.Input)

--- a/api/server/user/internal/infrastructure/validation/chat_test.go
+++ b/api/server/user/internal/infrastructure/validation/chat_test.go
@@ -11,37 +11,44 @@ import (
 )
 
 func TestChatDomainValidation_Room(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		room *chat.Room
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Room     *chat.Room
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			Room: &chat.Room{
-				ID:            "00000000-0000-0000-0000-000000000000",
-				UserIDs:       []string{"00000000-0000-0000-0000-000000000000"},
-				CreatedAt:     current,
-				UpdatedAt:     current,
-				LatestMessage: &chat.Message{},
+			args: args{
+				room: &chat.Room{
+					ID: "00000000-0000-0000-0000-000000000000",
+					UserIDs: []string{
+						"00000000-0000-0000-0000-000000000000",
+						"11111111-1111-1111-1111-111111111111",
+					},
+					CreatedAt: current,
+					UpdatedAt: current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewChatDomainValidation()
 
-			got := target.Room(ctx, tc.Room)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.Room(ctx, tc.args.room)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("want %#v, but %#v", tc.want, got)
 			}
 		})
 	}

--- a/api/server/user/internal/infrastructure/validation/user_test.go
+++ b/api/server/user/internal/infrastructure/validation/user_test.go
@@ -12,40 +12,45 @@ import (
 )
 
 func TestUserDomainValidation_User(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		user *user.User
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		User     *user.User
-		Expected error
+		args args
+		want error
 	}{
 		"ok": {
-			User: &user.User{
-				ID:               "00000000-0000-0000-0000-000000000000",
-				Username:         "test-user",
-				Gender:           0,
-				Email:            "test-user@calmato.com",
-				PhoneNumber:      "000-0000-0000",
-				Role:             0,
-				ThumbnailURL:     "",
-				SelfIntroduction: "",
-				LastName:         "テスト",
-				FirstName:        "ユーザ",
-				LastNameKana:     "てすと",
-				FirstNameKana:    "ゆーざ",
-				PostalCode:       "000-0000",
-				Prefecture:       "東京都",
-				City:             "小金井市",
-				AddressLine1:     "貫井北町4-1-1",
-				AddressLine2:     "",
-				InstanceID:       "",
-				CreatedAt:        current,
-				UpdatedAt:        current,
+			args: args{
+				user: &user.User{
+					ID:               "00000000-0000-0000-0000-000000000000",
+					Username:         "test-user",
+					Gender:           0,
+					Email:            "test-user@calmato.com",
+					PhoneNumber:      "000-0000-0000",
+					Role:             0,
+					ThumbnailURL:     "",
+					SelfIntroduction: "",
+					LastName:         "テスト",
+					FirstName:        "ユーザ",
+					LastNameKana:     "てすと",
+					FirstNameKana:    "ゆーざ",
+					PostalCode:       "000-0000",
+					Prefecture:       "東京都",
+					City:             "小金井市",
+					AddressLine1:     "貫井北町4-1-1",
+					AddressLine2:     "",
+					InstanceID:       "",
+					CreatedAt:        current,
+					UpdatedAt:        current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -53,39 +58,44 @@ func TestUserDomainValidation_User(t *testing.T) {
 		defer ctrl.Finish()
 
 		urm := mock_user.NewMockRepository(ctrl)
-		urm.EXPECT().GetUIDByEmail(ctx, tc.User.Email).Return(tc.User.ID, nil)
+		urm.EXPECT().GetUIDByEmail(ctx, tc.args.user.Email).Return(tc.args.user.ID, nil)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserDomainValidation(urm)
 
-			got := target.User(ctx, tc.User)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.User(ctx, tc.args.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
 			}
 		})
 	}
 }
 
 func TestUserDomainValidation_Relationship(t *testing.T) {
-	current := time.Now()
+	type args struct {
+		relationship *user.Relationship
+	}
 
+	current := time.Now().Local()
 	testCases := map[string]struct {
-		Relationship *user.Relationship
-		Expected     error
+		args args
+		want error
 	}{
 		"ok": {
-			Relationship: &user.Relationship{
-				ID:         1,
-				FollowID:   "00000000-0000-0000-0000-000000000000",
-				FollowerID: "11111111-1111-1111-1111-111111111111",
-				CreatedAt:  current,
-				UpdatedAt:  current,
+			args: args{
+				relationship: &user.Relationship{
+					ID:         1,
+					FollowID:   "00000000-0000-0000-0000-000000000000",
+					FollowerID: "11111111-1111-1111-1111-111111111111",
+					CreatedAt:  current,
+					UpdatedAt:  current,
+				},
 			},
-			Expected: nil,
+			want: nil,
 		},
 	}
 
-	for result, tc := range testCases {
+	for name, tc := range testCases {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -94,15 +104,15 @@ func TestUserDomainValidation_Relationship(t *testing.T) {
 
 		urm := mock_user.NewMockRepository(ctrl)
 		urm.EXPECT().
-			GetRelationshipIDByUID(ctx, tc.Relationship.FollowID, tc.Relationship.FollowerID).
-			Return(tc.Relationship.ID, nil)
+			GetRelationshipIDByUID(ctx, tc.args.relationship.FollowID, tc.args.relationship.FollowerID).
+			Return(tc.args.relationship.ID, nil)
 
-		t.Run(result, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			target := NewUserDomainValidation(urm)
 
-			got := target.Relationship(ctx, tc.Relationship)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("want %#v, but %#v", tc.Expected, got)
+			got := target.Relationship(ctx, tc.args.relationship)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("want %#v, but %#v", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* APIのテストの書き方を統一した

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* テストのフォーマットとしては↓の形にした

```go
func Test<interface name>_<method name>(t *testing.T) {
	type args struct {
		// Add the arguments to be passed to the function.
	}
	type want struct {
		err error
		// Add the return value from a function.
	}

	testCases := map[string]struct {
		args args
		want want
	}{
		"<test case name>": {
			args: args{
				// Add test cases.
			},
			want: want{
				// Add test cases.
			},
		},
	}

	for name, tc := range testCases {
		ctx, cancel := context.WithCancel(context.Background())
		defer cancel()

		ctrl := gomock.NewController(t)
		defer ctrl.Finish()

		// Add dependencies for structure fields.

		t.Run(name, func(t *testing.T) {
			target := New<interface name>()

			got, err := target.<method name>(ctx)
			if !reflect.DeepEqual(err, tc.want.err) {
				t.Fatalf("want %#v, but %#v", tc.want.err, err)
				return
			}

			// Add other test items.
		})
	}
}
```
