### PR TITLE
fix: ユーザー登録時に認証用メールが送信されない不具合を修正

### DIFF
--- a/native/app/store/usecases/auth.ts
+++ b/native/app/store/usecases/auth.ts
@@ -162,7 +162,7 @@ export function signUpWithEmailAsync(
         username,
       })
       .then(async (res: AxiosResponse<IAuthResponse>) => {
-        console.log('debug', res);
+        return sendEmailVerification()
       })
       .catch((err: Error) => {
         throw err;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
Firebase Admin for SDKにメール送信メソッドが存在しなかったため、クライアント側から送信リクエストをしていたが、ユーザ登録後の処理にはこの処理が含まれていなかったため追加した。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
