### PR TITLE
fix: タイムゾーン変換周りでPanicが起きているのを修正

### DIFF
--- a/api/gateway/native/pkg/datetime/jst.go
+++ b/api/gateway/native/pkg/datetime/jst.go
@@ -6,10 +6,8 @@ type Time struct {
 	time time.Time
 }
 
-const location = "Asia/Tokyo"
-
 var (
-	jst, _ = time.LoadLocation(location)
+	jst = time.FixedZone("JST", 9*60*60)
 )
 
 func New(t time.Time) *Time {

--- a/api/gateway/native/pkg/datetime/jst_test.go
+++ b/api/gateway/native/pkg/datetime/jst_test.go
@@ -1,0 +1,83 @@
+package datetime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  time.Time
+		expect *Time
+	}{
+		{
+			name:  "success",
+			input: time.Date(2021, time.Month(8), 1, 0, 0, 0, 0, jst),
+			expect: &Time{
+				time: time.Date(2021, time.Month(8), 1, 0, 0, 0, 0, jst),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, New(tt.input))
+		})
+	}
+}
+
+func TestTime_BeggingOfMonth(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		time   *Time
+		expect time.Time
+	}{
+		{
+			name: "success",
+			time: &Time{
+				time: time.Date(2021, time.Month(8), 15, 12, 0, 0, 0, jst),
+			},
+			expect: time.Date(2021, time.Month(8), 1, 0, 0, 0, 0, jst),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.time.BeginningOfMonth())
+		})
+	}
+}
+
+func TestTime_EndOfMonth(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		time   *Time
+		expect time.Time
+	}{
+		{
+			name: "success",
+			time: &Time{
+				time: time.Date(2021, time.Month(8), 15, 12, 0, 0, 0, jst),
+			},
+			expect: time.Date(2021, time.Month(8), 31, 23, 59, 59, 0, jst),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.time.EndOfMonth())
+		})
+	}
+}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* タイムゾーン変換周りでPanicが起きているのを修正

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
